### PR TITLE
chore: Add justfile consolidating dev commands.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,8 @@ Frontend dev server at `http://localhost:5173` (port 3000 is only the Docker ngi
 
 ## Build/Lint/Test Commands
 
+A `justfile` wraps the common dev commands: `just server`, `just frontend`, `just seed`, `just check`, `just test`, `just build`, `just release`. The underlying commands are listed below.
+
 ### Backend (Python)
 - **Lint**: `uv run ruff check .`
 - **Format**: `uv run ruff format .`

--- a/justfile
+++ b/justfile
@@ -1,0 +1,35 @@
+# Development commands for leggen. Run `just` to list recipes.
+
+set quiet
+
+default:
+    just --list
+
+# Start the API server with the local test database and config
+server:
+    LEGGEN_DATABASE_PATH=./test-data.db LEGGEN_CONFIG_FILE=./config.toml uv run leggen server --reload
+
+# Start the frontend dev server (http://localhost:5173)
+frontend:
+    cd frontend && npm install && npm run dev
+
+# Generate a mock database at ./test-data.db
+seed accounts="5" transactions="100":
+    uv run leggen --config config.toml generate_sample_db --database ./test-data.db --accounts {{accounts}} --transactions {{transactions}} --force
+
+# Run all backend checks (ruff, mypy, hooks) and frontend lint
+check:
+    uv run pre-commit run --all-files
+    cd frontend && npm run lint
+
+# Run the backend test suite; pass extra pytest args after --
+test *args:
+    uv run pytest {{args}}
+
+# Build the frontend for production
+build:
+    cd frontend && npm run build
+
+# Cut a release (CalVer bump, changelog, tag)
+release:
+    ./scripts/release.sh


### PR DESCRIPTION
Adds a `justfile` at the repo root wrapping the dev commands that were previously scattered across CLAUDE.md/README:

- `just server` — API server with local test DB and config
- `just frontend` — frontend dev server
- `just seed [accounts] [transactions]` — generate mock database
- `just check` — pre-commit (ruff, mypy, hooks) + frontend eslint
- `just test [args]` — pytest, extra args pass through
- `just build` — production frontend build
- `just release` — scripts/release.sh

Also adds a one-line pointer in AGENTS.md. Baseline: 216 tests pass.

PR 1 of the polish series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)