### PR TITLE
fix: Bug sweep — schedule wipe, CLI exit codes, EnableBanking lifecycle.

### DIFF
--- a/leggen/api/routes/banks.py
+++ b/leggen/api/routes/banks.py
@@ -12,14 +12,19 @@ from leggen.api.models.banks import (
     BankInstitution,
 )
 from leggen.repositories import SessionRepository
-from leggen.services.enablebanking_service import EnableBankingService
+from leggen.services.enablebanking_service import (
+    EnableBankingService,
+    get_enablebanking_service,
+)
 
 router = APIRouter()
 
 
 @router.get("/banks/institutions")
 async def get_bank_institutions(
-    enablebanking_service: Annotated[EnableBankingService, Depends()],
+    enablebanking_service: Annotated[
+        EnableBankingService, Depends(get_enablebanking_service)
+    ],
     country: str = Query(default="PT", description="Country code (e.g., PT, ES, FR)"),
 ) -> list[BankInstitution]:
     """Get available bank institutions (ASPSPs) for a country"""
@@ -47,7 +52,9 @@ async def get_bank_institutions(
 @router.post("/banks/connect")
 async def connect_to_bank(
     request: BankConnectionRequest,
-    enablebanking_service: Annotated[EnableBankingService, Depends()],
+    enablebanking_service: Annotated[
+        EnableBankingService, Depends(get_enablebanking_service)
+    ],
 ) -> BankAuthResponse:
     """Start bank authorization flow"""
     try:
@@ -82,7 +89,9 @@ async def connect_to_bank(
 @router.post("/banks/callback")
 async def bank_auth_callback(
     request: BankCallbackRequest,
-    enablebanking_service: Annotated[EnableBankingService, Depends()],
+    enablebanking_service: Annotated[
+        EnableBankingService, Depends(get_enablebanking_service)
+    ],
     session_repo: Annotated[SessionRepository, Depends()],
 ) -> dict:
     """Exchange authorization code for a session"""

--- a/leggen/api/routes/sync.py
+++ b/leggen/api/routes/sync.py
@@ -87,7 +87,11 @@ async def update_sync_schedule(request: SyncScheduleRequest) -> SyncScheduleResp
         if request.cron:
             sync_config["cron"] = request.cron
 
-        config.update_section("scheduler", {"sync": sync_config})
+        # Merge into the existing section: replacing it wholesale would reset
+        # the backup schedule to defaults.
+        scheduler_section = dict(config.scheduler_config)
+        scheduler_section["sync"] = sync_config
+        config.update_section("scheduler", scheduler_section)
         scheduler.reschedule_sync(sync_config)
 
         next_sync = scheduler.get_next_sync_time()

--- a/leggen/api_client.py
+++ b/leggen/api_client.py
@@ -1,11 +1,17 @@
-import os
 from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urljoin, urlparse
 
+import click
 import requests
 import urllib3
 
-from leggen.utils.text import error
+
+class LeggenAPIError(click.ClickException):
+    """A request to the leggen server failed.
+
+    Subclasses ClickException so commands exit non-zero with the message
+    printed to stderr, without per-command error handling.
+    """
 
 
 class LeggenAPIClient:
@@ -19,11 +25,8 @@ class LeggenAPIClient:
         verify_ssl: bool = True,
         api_key: Optional[str] = None,
     ):
-        raw_url = (
-            base_url
-            or os.environ.get("LEGGEN_API_URL", "http://localhost:8000")
-            or "http://localhost:8000"
-        )
+        # Env-var resolution (LEGGEN_API_URL) happens in the CLI option
+        raw_url = base_url or "http://localhost:8000"
         # Ensure base_url includes /api/v1 path if not already present
         parsed = urlparse(raw_url)
         if not parsed.path or parsed.path == "/":
@@ -45,6 +48,15 @@ class LeggenAPIClient:
         if api_key:
             self.session.headers["X-API-Key"] = api_key
 
+    @classmethod
+    def from_context(cls, ctx: click.Context) -> "LeggenAPIClient":
+        """Build a client from the global CLI options stored on the context."""
+        return cls(
+            ctx.obj.get("api_url"),
+            verify_ssl=ctx.obj.get("verify_ssl", True),
+            api_key=ctx.obj.get("api_key"),
+        )
+
     def _make_request(self, method: str, endpoint: str, **kwargs) -> Any:
         """Make HTTP request to the API"""
         # Construct URL by joining base_url with endpoint
@@ -62,30 +74,22 @@ class LeggenAPIClient:
             )
             response.raise_for_status()
             return response.json()
-        except requests.exceptions.ConnectionError:
-            error("Could not connect to leggen server. Is it running?")
-            error(f"Trying to connect to: {self.base_url}")
-            raise
+        except requests.exceptions.ConnectionError as e:
+            raise LeggenAPIError(
+                f"Could not connect to the leggen server at {self.base_url}. "
+                "Is it running?"
+            ) from e
         except requests.exceptions.HTTPError as e:
-            error(f"API request failed: {e}")
-            if response.text:
-                try:
-                    error_data = response.json()
-                    error(f"Error details: {error_data.get('detail', 'Unknown error')}")
-                except Exception:
-                    error(f"Response: {response.text}")
-            raise
-        except Exception as e:
-            error(f"Unexpected error: {e}")
-            raise
-
-    def health_check(self) -> bool:
-        """Check if the leggen server is healthy"""
-        try:
-            response = self._make_request("GET", "/health")
-            return response.get("status") == "healthy"
-        except Exception:
-            return False
+            message = f"API request failed: {e}"
+            try:
+                detail = response.json().get("detail")
+            except Exception:
+                detail = response.text or None
+            if detail:
+                message = f"{message}\n{detail}"
+            raise LeggenAPIError(message) from e
+        except requests.exceptions.RequestException as e:
+            raise LeggenAPIError(f"API request failed: {e}") from e
 
     # Bank endpoints
     def get_institutions(self, country: str = "PT") -> List[Dict[str, Any]]:

--- a/leggen/api_client.py
+++ b/leggen/api_client.py
@@ -115,9 +115,11 @@ class LeggenAPIClient:
         response = self._make_request("POST", "/banks/connect", json=payload)
         return response
 
-    def exchange_auth_code(self, code: str) -> Dict[str, Any]:
+    def exchange_auth_code(self, code: str, state: str) -> Dict[str, Any]:
         """Exchange authorization code for a session"""
-        response = self._make_request("POST", "/banks/callback", json={"code": code})
+        response = self._make_request(
+            "POST", "/banks/callback", json={"code": code, "state": state}
+        )
         return response
 
     def get_bank_status(self) -> List[Dict[str, Any]]:

--- a/leggen/background/scheduler.py
+++ b/leggen/background/scheduler.py
@@ -101,6 +101,11 @@ class BackgroundScheduler:
             self.scheduler.shutdown()
             logger.info("Background scheduler shutdown")
 
+    async def close_services(self) -> None:
+        """Close HTTP clients owned by lazily created services."""
+        if self._sync_service is not None:
+            await self._sync_service.enablebanking.aclose()
+
     def reschedule_sync(self, schedule_config: dict):
         """Reschedule the sync job with new configuration"""
         if self.scheduler.running:

--- a/leggen/commands/balances.py
+++ b/leggen/commands/balances.py
@@ -11,18 +11,7 @@ def balances(ctx: click.Context):
     """
     List balances of all connected accounts
     """
-    api_client = LeggenAPIClient(
-        ctx.obj.get("api_url"),
-        verify_ssl=ctx.obj.get("verify_ssl", True),
-        api_key=ctx.obj.get("api_key"),
-    )
-
-    # Check if leggen server is available
-    if not api_client.health_check():
-        click.echo(
-            "Error: Cannot connect to leggen server. Please ensure it's running."
-        )
-        return
+    api_client = LeggenAPIClient.from_context(ctx)
 
     accounts = api_client.get_accounts()
 

--- a/leggen/commands/bank/add.py
+++ b/leggen/commands/bank/add.py
@@ -12,87 +12,71 @@ def add(ctx):
     """
     Connect to a bank
     """
-    api_client = LeggenAPIClient(
-        ctx.obj.get("api_url"),
-        verify_ssl=ctx.obj.get("verify_ssl", True),
-        api_key=ctx.obj.get("api_key"),
+    api_client = LeggenAPIClient.from_context(ctx)
+
+    # Get supported countries
+    countries = api_client.get_supported_countries()
+    country_codes = [c["code"] for c in countries]
+
+    country = click.prompt(
+        "Bank Country",
+        type=click.Choice(country_codes, case_sensitive=True),
+        default="PT",
     )
 
-    # Check if leggen server is available
-    if not api_client.health_check():
-        click.echo(
-            "Error: Cannot connect to leggen server. Please ensure it's running."
-        )
+    info(f"Getting bank list for country: {country}")
+    banks = api_client.get_institutions(country)
+
+    if not banks:
+        warning(f"No banks available for country {country}")
         return
 
-    try:
-        # Get supported countries
-        countries = api_client.get_supported_countries()
-        country_codes = [c["code"] for c in countries]
+    filtered_banks = [
+        {
+            "name": bank["name"],
+            "country": bank.get("country", country),
+            "bic": bank.get("bic", ""),
+        }
+        for bank in banks
+    ]
+    print_table(filtered_banks)
 
-        country = click.prompt(
-            "Bank Country",
-            type=click.Choice(country_codes, case_sensitive=True),
-            default="PT",
-        )
+    allowed_names = [str(bank["name"]) for bank in banks]
+    bank_name = click.prompt("Bank Name", type=click.Choice(allowed_names))
 
-        info(f"Getting bank list for country: {country}")
-        banks = api_client.get_institutions(country)
+    # Show bank details
+    info(f"Selected bank: {bank_name}")
 
-        if not banks:
-            warning(f"No banks available for country {country}")
-            return
+    click.confirm("Do you agree to connect to this bank?", abort=True)
 
-        filtered_banks = [
-            {
-                "name": bank["name"],
-                "country": bank.get("country", country),
-                "bic": bank.get("bic", ""),
-            }
-            for bank in banks
-        ]
-        print_table(filtered_banks)
+    info(f"Connecting to bank: {bank_name}")
 
-        allowed_names = [str(bank["name"]) for bank in banks]
-        bank_name = click.prompt("Bank Name", type=click.Choice(allowed_names))
+    # Connect to bank via API
+    result = api_client.connect_to_bank(bank_name, country)
 
-        # Show bank details
-        info(f"Selected bank: {bank_name}")
+    success("Bank authorization request created!")
+    warning(
+        "Please open the following URL in your browser to authorize the connection:"
+    )
+    click.echo(f"\n{result['url']}\n")
 
-        click.confirm("Do you agree to connect to this bank?", abort=True)
+    info("After completing the authorization, paste the callback URL here.")
+    callback_url = click.prompt("Callback URL")
 
-        info(f"Connecting to bank: {bank_name}")
+    # Parse the code from the callback URL
+    parsed = urlparse(callback_url)
+    query_params = parse_qs(parsed.query)
+    code = query_params.get("code", [None])[0]
 
-        # Connect to bank via API
-        result = api_client.connect_to_bank(bank_name, country)
+    if not code:
+        raise click.ClickException("No authorization code found in the callback URL.")
 
-        success("Bank authorization request created!")
-        warning(
-            "Please open the following URL in your browser to authorize the connection:"
-        )
-        click.echo(f"\n{result['url']}\n")
+    # Exchange the code for a session
+    session = api_client.exchange_auth_code(code)
 
-        info("After completing the authorization, paste the callback URL here.")
-        callback_url = click.prompt("Callback URL")
-
-        # Parse the code from the callback URL
-        parsed = urlparse(callback_url)
-        query_params = parse_qs(parsed.query)
-        code = query_params.get("code", [None])[0]
-
-        if not code:
-            click.echo("Error: No authorization code found in the callback URL.")
-            return
-
-        # Exchange the code for a session
-        session = api_client.exchange_auth_code(code)
-
-        success("Bank connection established!")
-        info(f"Session ID: {session['session_id']}")
-        info(f"Bank: {session['aspsp_name']} ({session['aspsp_country']})")
-        accounts = session.get("accounts", [])
-        info(f"Accounts: {len(accounts) if accounts else 0}")
-        info("You can now sync your accounts with 'leggen sync'")
-
-    except Exception as e:
-        click.echo(f"Error: Failed to connect to bank: {str(e)}")
+    success("Bank connection established!")
+    info(f"Session ID: {session['session_id']}")
+    info(f"Bank: {session['aspsp_name']} ({session['aspsp_country']})")
+    accounts = session.get("accounts", [])
+    info(f"Accounts: {len(accounts) if accounts else 0}")
+    info("You can now sync your accounts with 'leggen sync'")

--- a/leggen/commands/bank/add.py
+++ b/leggen/commands/bank/add.py
@@ -63,16 +63,20 @@ def add(ctx):
     info("After completing the authorization, paste the callback URL here.")
     callback_url = click.prompt("Callback URL")
 
-    # Parse the code from the callback URL
+    # Parse the code and state from the callback URL; the server requires
+    # both to redeem the session (state is its CSRF check)
     parsed = urlparse(callback_url)
     query_params = parse_qs(parsed.query)
     code = query_params.get("code", [None])[0]
+    state = query_params.get("state", [None])[0]
 
-    if not code:
-        raise click.ClickException("No authorization code found in the callback URL.")
+    if not code or not state:
+        raise click.ClickException(
+            "No authorization code and state found in the callback URL."
+        )
 
     # Exchange the code for a session
-    session = api_client.exchange_auth_code(code)
+    session = api_client.exchange_auth_code(code, state)
 
     success("Bank connection established!")
     info(f"Session ID: {session['session_id']}")

--- a/leggen/commands/bank/delete.py
+++ b/leggen/commands/bank/delete.py
@@ -15,11 +15,7 @@ def delete(ctx, session_id: str):
 
     Check `leggen status` to get the SESSION_ID
     """
-    api_client = LeggenAPIClient(
-        ctx.obj.get("api_url"),
-        verify_ssl=ctx.obj.get("verify_ssl", True),
-        api_key=ctx.obj.get("api_key"),
-    )
+    api_client = LeggenAPIClient.from_context(ctx)
 
     info(f"Deleting bank session: {session_id}")
 

--- a/leggen/commands/server.py
+++ b/leggen/commands/server.py
@@ -80,6 +80,7 @@ async def lifespan(app: FastAPI):
     # Shutdown
     logger.info("Shutting down leggen server...")
     scheduler.shutdown()
+    await scheduler.close_services()
     await close_enablebanking_service()
 
 

--- a/leggen/commands/server.py
+++ b/leggen/commands/server.py
@@ -22,6 +22,7 @@ from leggen.api.routes import (
 )
 from leggen.background.scheduler import scheduler
 from leggen.repositories import MigrationRepository, ensure_tables
+from leggen.services.enablebanking_service import close_enablebanking_service
 from leggen.utils.config import config
 from leggen.utils.paths import path_manager
 
@@ -79,6 +80,7 @@ async def lifespan(app: FastAPI):
     # Shutdown
     logger.info("Shutting down leggen server...")
     scheduler.shutdown()
+    await close_enablebanking_service()
 
 
 def create_app() -> FastAPI:

--- a/leggen/commands/status.py
+++ b/leggen/commands/status.py
@@ -11,18 +11,7 @@ def status(ctx: click.Context):
     """
     List all connected banks and their status
     """
-    api_client = LeggenAPIClient(
-        ctx.obj.get("api_url"),
-        verify_ssl=ctx.obj.get("verify_ssl", True),
-        api_key=ctx.obj.get("api_key"),
-    )
-
-    # Check if leggen server is available
-    if not api_client.health_check():
-        click.echo(
-            "Error: Cannot connect to leggen server. Please ensure it's running."
-        )
-        return
+    api_client = LeggenAPIClient.from_context(ctx)
 
     # Get bank connection status
     bank_connections = api_client.get_bank_status()

--- a/leggen/commands/sync.py
+++ b/leggen/commands/sync.py
@@ -19,41 +19,24 @@ def sync(ctx: click.Context, full: bool, accounts: tuple[str, ...]):
     """
     Sync transactions with database
     """
-    api_client = LeggenAPIClient(
-        ctx.obj.get("api_url"),
-        verify_ssl=ctx.obj.get("verify_ssl", True),
-        api_key=ctx.obj.get("api_key"),
-    )
+    api_client = LeggenAPIClient.from_context(ctx)
 
-    # Check if leggen server is available
-    if not api_client.health_check():
-        error("Cannot connect to leggen server. Please ensure it's running.")
-        return
+    info("Starting sync...")
+    result = api_client.trigger_sync(account_ids=list(accounts) or None, full_sync=full)
 
-    try:
-        info("Starting sync...")
-        result = api_client.trigger_sync(
-            account_ids=list(accounts) or None, full_sync=full
-        )
+    if not result.get("success"):
+        for err in result.get("errors", []):
+            error(f"  - {err}")
+        raise click.ClickException("Sync failed")
 
-        if result.get("success"):
-            success("Sync completed successfully!")
-            info(f"Accounts processed: {result.get('accounts_processed', 0)}")
-            info(f"Transactions added: {result.get('transactions_added', 0)}")
-            info(f"Balances updated: {result.get('balances_updated', 0)}")
-            if result.get("duration_seconds"):
-                info(f"Duration: {result['duration_seconds']:.2f} seconds")
+    success("Sync completed successfully!")
+    info(f"Accounts processed: {result.get('accounts_processed', 0)}")
+    info(f"Transactions added: {result.get('transactions_added', 0)}")
+    info(f"Balances updated: {result.get('balances_updated', 0)}")
+    if result.get("duration_seconds"):
+        info(f"Duration: {result['duration_seconds']:.2f} seconds")
 
-            if result.get("errors"):
-                error(f"Errors encountered: {len(result['errors'])}")
-                for err in result["errors"]:
-                    error(f"  - {err}")
-        else:
-            error("Sync failed")
-            if result.get("errors"):
-                for err in result["errors"]:
-                    error(f"  - {err}")
-
-    except Exception as e:
-        error(f"Sync failed: {str(e)}")
-        return
+    if result.get("errors"):
+        error(f"Errors encountered: {len(result['errors'])}")
+        for err in result["errors"]:
+            error(f"  - {err}")

--- a/leggen/commands/transactions.py
+++ b/leggen/commands/transactions.py
@@ -20,77 +20,59 @@ def transactions(ctx: click.Context, account: str, limit: int, full: bool):
 
     If the --account option is used, it will only list transactions for that account.
     """
-    api_client = LeggenAPIClient(
-        ctx.obj.get("api_url"),
-        verify_ssl=ctx.obj.get("verify_ssl", True),
-        api_key=ctx.obj.get("api_key"),
+    api_client = LeggenAPIClient.from_context(ctx)
+
+    if account:
+        # Get account details for display
+        accounts = api_client.get_accounts()
+        account_details = next((a for a in accounts if a["id"] == account), None)
+        if account_details:
+            info(f"Bank: {account_details['institution_id']}")
+            info(f"IBAN: {account_details.get('iban', 'N/A')}")
+
+    # Get transactions (with optional account filter)
+    transactions_data = api_client.get_all_transactions(
+        limit=limit, summary_only=not full, account_id=account
     )
 
-    # Check if leggen server is available
-    if not api_client.health_check():
-        click.echo(
-            "Error: Cannot connect to leggen server. Please ensure it's running."
-        )
-        return
+    # Format transactions for display
+    if full:
+        # Full transaction details
+        formatted_transactions = []
+        for txn in transactions_data:
+            # Handle optional internal_transaction_id
+            txn_id = txn.get("internal_transaction_id")
+            txn_id_display = txn_id[:12] + "..." if txn_id else "N/A"
 
-    try:
-        if account:
-            # Get account details for display
-            accounts = api_client.get_accounts()
-            account_details = next((a for a in accounts if a["id"] == account), None)
-            if account_details:
-                info(f"Bank: {account_details['institution_id']}")
-                info(f"IBAN: {account_details.get('iban', 'N/A')}")
+            formatted_transactions.append(
+                {
+                    "ID": txn_id_display,
+                    "Date": datefmt(txn["transaction_date"]),
+                    "Description": txn["description"][:50] + "..."
+                    if len(txn["description"]) > 50
+                    else txn["description"],
+                    "Amount": f"{txn['transaction_value']:.2f} {txn['transaction_currency']}",
+                    "Status": txn["transaction_status"].upper(),
+                    "Account": txn["account_id"][:8] + "...",
+                }
+            )
+    else:
+        # Summary view
+        formatted_transactions = []
+        for txn in transactions_data:
+            formatted_transactions.append(
+                {
+                    "Date": datefmt(txn["date"]),
+                    "Description": txn["description"][:60] + "..."
+                    if len(txn["description"]) > 60
+                    else txn["description"],
+                    "Amount": f"{txn['amount']:.2f} {txn['currency']}",
+                    "Status": txn["status"].upper(),
+                }
+            )
 
-        # Get transactions (with optional account filter)
-        transactions_data = api_client.get_all_transactions(
-            limit=limit, summary_only=not full, account_id=account
-        )
-
-        # Format transactions for display
-        if full:
-            # Full transaction details
-            formatted_transactions = []
-            for txn in transactions_data:
-                # Handle optional internal_transaction_id
-                txn_id = txn.get("internal_transaction_id")
-                txn_id_display = txn_id[:12] + "..." if txn_id else "N/A"
-
-                formatted_transactions.append(
-                    {
-                        "ID": txn_id_display,
-                        "Date": datefmt(txn["transaction_date"]),
-                        "Description": txn["description"][:50] + "..."
-                        if len(txn["description"]) > 50
-                        else txn["description"],
-                        "Amount": f"{txn['transaction_value']:.2f} {txn['transaction_currency']}",
-                        "Status": txn["transaction_status"].upper(),
-                        "Account": txn["account_id"][:8] + "...",
-                    }
-                )
-        else:
-            # Summary view
-            formatted_transactions = []
-            for txn in transactions_data:
-                # Handle optional internal_transaction_id
-                txn_id = txn.get("internal_transaction_id")
-
-                formatted_transactions.append(
-                    {
-                        "Date": datefmt(txn["date"]),
-                        "Description": txn["description"][:60] + "..."
-                        if len(txn["description"]) > 60
-                        else txn["description"],
-                        "Amount": f"{txn['amount']:.2f} {txn['currency']}",
-                        "Status": txn["status"].upper(),
-                    }
-                )
-
-        if formatted_transactions:
-            print_table(formatted_transactions)
-            info(f"Showing {len(formatted_transactions)} transactions")
-        else:
-            info("No transactions found")
-
-    except Exception as e:
-        click.echo(f"Error: Failed to get transactions: {str(e)}")
+    if formatted_transactions:
+        print_table(formatted_transactions)
+        info(f"Showing {len(formatted_transactions)} transactions")
+    else:
+        info("No transactions found")

--- a/leggen/services/enablebanking_service.py
+++ b/leggen/services/enablebanking_service.py
@@ -10,8 +10,8 @@ from loguru import logger
 
 from leggen.utils.config import config
 
-# States issued by start_auth, awaiting the bank redirect. Module-level
-# because a fresh service instance is created per request via Depends().
+# States issued by start_auth, awaiting the bank redirect. Module-level so
+# they are shared across all service instances (routes and sync service).
 _pending_auth_states: Dict[str, float] = {}
 
 
@@ -187,6 +187,11 @@ class EnableBankingService:
             and time.time() - issued_at <= self.AUTH_STATE_TTL_SECONDS
         )
 
+    async def aclose(self) -> None:
+        """Close the underlying HTTP client."""
+        if self._client is not None and not self._client.is_closed:
+            await self._client.aclose()
+
     async def create_session(self, code: str) -> Dict[str, Any]:
         """Exchange authorization code for a session."""
         return await self._make_request("POST", "/sessions", json={"code": code})
@@ -222,3 +227,25 @@ class EnableBankingService:
             params["continuation_key"] = continuation_key
 
         return {"transactions": all_transactions}
+
+
+# Application-scoped instance for FastAPI routes. A per-request instance
+# (bare Depends()) would leak an unclosed httpx.AsyncClient per request and
+# defeat the JWT and ASPSP caches.
+_service: Optional[EnableBankingService] = None
+
+
+def get_enablebanking_service() -> EnableBankingService:
+    """FastAPI dependency returning the app-scoped service instance."""
+    global _service
+    if _service is None:
+        _service = EnableBankingService()
+    return _service
+
+
+async def close_enablebanking_service() -> None:
+    """Close the app-scoped service's HTTP client (lifespan shutdown)."""
+    global _service
+    if _service is not None:
+        await _service.aclose()
+        _service = None

--- a/leggen/services/enablebanking_service.py
+++ b/leggen/services/enablebanking_service.py
@@ -1,3 +1,4 @@
+import threading
 import time
 import uuid
 from datetime import datetime, timedelta, timezone
@@ -233,13 +234,17 @@ class EnableBankingService:
 # (bare Depends()) would leak an unclosed httpx.AsyncClient per request and
 # defeat the JWT and ASPSP caches.
 _service: Optional[EnableBankingService] = None
+# Sync dependencies run in FastAPI's threadpool, so creation must be locked.
+_service_lock = threading.Lock()
 
 
 def get_enablebanking_service() -> EnableBankingService:
     """FastAPI dependency returning the app-scoped service instance."""
     global _service
     if _service is None:
-        _service = EnableBankingService()
+        with _service_lock:
+            if _service is None:
+                _service = EnableBankingService()
     return _service
 
 

--- a/tests/unit/test_api_banks.py
+++ b/tests/unit/test_api_banks.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from leggen.services.enablebanking_service import EnableBankingService
+from leggen.services.enablebanking_service import get_enablebanking_service
 
 
 @pytest.mark.api
@@ -17,12 +17,12 @@ class TestBanksAPI:
         """Test successful retrieval of bank institutions."""
         mock_eb = AsyncMock()
         mock_eb.get_aspsps.return_value = sample_bank_data["aspsps"]
-        fastapi_app.dependency_overrides[EnableBankingService] = lambda: mock_eb
+        fastapi_app.dependency_overrides[get_enablebanking_service] = lambda: mock_eb
 
         with patch("leggen.utils.config.config", mock_config):
             response = api_client.get("/api/v1/banks/institutions?country=PT")
 
-        fastapi_app.dependency_overrides.pop(EnableBankingService, None)
+        fastapi_app.dependency_overrides.pop(get_enablebanking_service, None)
 
         assert response.status_code == 200
         data = response.json()
@@ -36,12 +36,12 @@ class TestBanksAPI:
         """Test institutions endpoint with invalid country code."""
         mock_eb = AsyncMock()
         mock_eb.get_aspsps.return_value = []
-        fastapi_app.dependency_overrides[EnableBankingService] = lambda: mock_eb
+        fastapi_app.dependency_overrides[get_enablebanking_service] = lambda: mock_eb
 
         with patch("leggen.utils.config.config", mock_config):
             response = api_client.get("/api/v1/banks/institutions?country=XX")
 
-        fastapi_app.dependency_overrides.pop(EnableBankingService, None)
+        fastapi_app.dependency_overrides.pop(get_enablebanking_service, None)
 
         assert response.status_code == 200
         data = response.json()
@@ -56,7 +56,7 @@ class TestBanksAPI:
         mock_eb.start_auth.return_value = {
             "url": "https://bank.example.com/auth?state=abc"
         }
-        fastapi_app.dependency_overrides[EnableBankingService] = lambda: mock_eb
+        fastapi_app.dependency_overrides[get_enablebanking_service] = lambda: mock_eb
 
         with patch("leggen.utils.config.config", mock_config):
             request_data = {
@@ -66,7 +66,7 @@ class TestBanksAPI:
             }
             response = api_client.post("/api/v1/banks/connect", json=request_data)
 
-        fastapi_app.dependency_overrides.pop(EnableBankingService, None)
+        fastapi_app.dependency_overrides.pop(get_enablebanking_service, None)
 
         assert response.status_code == 200
         data = response.json()
@@ -84,13 +84,13 @@ class TestBanksAPI:
         mock_eb.start_auth.return_value = {
             "url": "https://bank.example.com/auth?state=abc"
         }
-        fastapi_app.dependency_overrides[EnableBankingService] = lambda: mock_eb
+        fastapi_app.dependency_overrides[get_enablebanking_service] = lambda: mock_eb
 
         with patch("leggen.utils.config.config", mock_config):
             request_data = {"aspsp_name": "Revolut", "aspsp_country": "GB"}
             response = api_client.post("/api/v1/banks/connect", json=request_data)
 
-        fastapi_app.dependency_overrides.pop(EnableBankingService, None)
+        fastapi_app.dependency_overrides.pop(get_enablebanking_service, None)
 
         assert response.status_code == 200
         assert mock_eb.start_auth.call_args.kwargs["maximum_consent_validity"] is None
@@ -107,7 +107,7 @@ class TestBanksAPI:
         mock_eb = AsyncMock()
         mock_eb.create_session.return_value = session_response
         mock_eb.consume_auth_state = MagicMock(return_value=True)
-        api_client.app.dependency_overrides[EnableBankingService] = lambda: mock_eb
+        api_client.app.dependency_overrides[get_enablebanking_service] = lambda: mock_eb
 
         with patch("leggen.utils.config.config", mock_config):
             response = api_client.post(
@@ -115,7 +115,7 @@ class TestBanksAPI:
                 json={"code": "test-auth-code", "state": "test-state"},
             )
 
-        api_client.app.dependency_overrides.pop(EnableBankingService, None)
+        api_client.app.dependency_overrides.pop(get_enablebanking_service, None)
 
         assert response.status_code == 200
         data = response.json()
@@ -129,7 +129,7 @@ class TestBanksAPI:
         """Callback rejects a state that was never issued by start_auth."""
         mock_eb = AsyncMock()
         mock_eb.consume_auth_state = MagicMock(return_value=False)
-        api_client.app.dependency_overrides[EnableBankingService] = lambda: mock_eb
+        api_client.app.dependency_overrides[get_enablebanking_service] = lambda: mock_eb
 
         with patch("leggen.utils.config.config", mock_config):
             response = api_client.post(
@@ -137,7 +137,7 @@ class TestBanksAPI:
                 json={"code": "test-auth-code", "state": "forged-state"},
             )
 
-        api_client.app.dependency_overrides.pop(EnableBankingService, None)
+        api_client.app.dependency_overrides.pop(get_enablebanking_service, None)
 
         assert response.status_code == 400
         mock_eb.create_session.assert_not_called()
@@ -155,7 +155,7 @@ class TestBanksAPI:
         mock_eb = AsyncMock()
         mock_eb.create_session.return_value = session_response
         mock_eb.consume_auth_state = MagicMock(return_value=True)
-        api_client.app.dependency_overrides[EnableBankingService] = lambda: mock_eb
+        api_client.app.dependency_overrides[get_enablebanking_service] = lambda: mock_eb
 
         with patch("leggen.utils.config.config", mock_config):
             api_client.post(
@@ -163,7 +163,7 @@ class TestBanksAPI:
                 json={"code": "test-code", "state": "test-state"},
             )
 
-        api_client.app.dependency_overrides.pop(EnableBankingService, None)
+        api_client.app.dependency_overrides.pop(get_enablebanking_service, None)
 
         # Now get status
         with patch("leggen.utils.config.config", mock_config):
@@ -202,7 +202,7 @@ class TestBanksAPI:
         mock_eb = AsyncMock()
         mock_eb.create_session.return_value = session_response
         mock_eb.consume_auth_state = MagicMock(return_value=True)
-        api_client.app.dependency_overrides[EnableBankingService] = lambda: mock_eb
+        api_client.app.dependency_overrides[get_enablebanking_service] = lambda: mock_eb
 
         with patch("leggen.utils.config.config", mock_config):
             api_client.post(
@@ -210,7 +210,7 @@ class TestBanksAPI:
                 json={"code": "test-code", "state": "test-state"},
             )
 
-        api_client.app.dependency_overrides.pop(EnableBankingService, None)
+        api_client.app.dependency_overrides.pop(get_enablebanking_service, None)
 
         # Delete the session
         with patch("leggen.utils.config.config", mock_config):

--- a/tests/unit/test_api_client.py
+++ b/tests/unit/test_api_client.py
@@ -1,40 +1,15 @@
 """Tests for CLI API client."""
 
-from unittest.mock import patch
-
 import pytest
 import requests
 import requests_mock
 
-from leggen.api_client import LeggenAPIClient
+from leggen.api_client import LeggenAPIClient, LeggenAPIError
 
 
 @pytest.mark.cli
 class TestLeggenAPIClient:
     """Test the CLI API client."""
-
-    def test_health_check_success(self):
-        """Test successful health check."""
-        client = LeggenAPIClient("http://localhost:8000")
-
-        with requests_mock.Mocker() as m:
-            m.get(
-                "http://localhost:8000/api/v1/health",
-                json={"status": "healthy"},
-            )
-
-            result = client.health_check()
-            assert result is True
-
-    def test_health_check_failure(self):
-        """Test health check failure."""
-        client = LeggenAPIClient("http://localhost:8000")
-
-        with requests_mock.Mocker() as m:
-            m.get("http://localhost:8000/health", status_code=500)
-
-            result = client.health_check()
-            assert result is False
 
     def test_get_institutions_success(self, sample_bank_data):
         """Test getting institutions via API client."""
@@ -92,15 +67,18 @@ class TestLeggenAPIClient:
             assert len(result) == 1
             assert result[0]["id"] == "test-account-123"
 
-    def test_connection_error_handling(self):
-        """Test handling of connection errors."""
-        client = LeggenAPIClient("http://localhost:9999")  # Non-existent service
+    def test_connection_error_raises_api_error(self):
+        """Connection failures surface as LeggenAPIError (a ClickException)."""
+        client = LeggenAPIClient("http://localhost:8000")
 
-        with pytest.raises((requests.ConnectionError, requests.RequestException)):
-            client.get_accounts()
+        with requests_mock.Mocker() as m:
+            m.get(requests_mock.ANY, exc=requests.exceptions.ConnectionError)
 
-    def test_http_error_handling(self):
-        """Test handling of HTTP errors."""
+            with pytest.raises(LeggenAPIError, match="Could not connect"):
+                client.get_accounts()
+
+    def test_http_error_raises_api_error_with_detail(self):
+        """HTTP errors surface as LeggenAPIError including the API detail."""
         client = LeggenAPIClient("http://localhost:8000")
 
         with requests_mock.Mocker() as m:
@@ -110,7 +88,7 @@ class TestLeggenAPIClient:
                 json={"detail": "Internal server error"},
             )
 
-            with pytest.raises((requests.HTTPError, requests.RequestException)):
+            with pytest.raises(LeggenAPIError, match="Internal server error"):
                 client.get_accounts()
 
     def test_custom_api_url(self):
@@ -119,12 +97,6 @@ class TestLeggenAPIClient:
         client = LeggenAPIClient(custom_url)
 
         assert client.base_url == f"{custom_url}/api/v1"
-
-    def test_environment_variable_url(self):
-        """Test using environment variable for API URL."""
-        with patch.dict("os.environ", {"LEGGEN_API_URL": "http://env-host:7000"}):
-            client = LeggenAPIClient()
-            assert client.base_url == "http://env-host:7000/api/v1"
 
     def test_trigger_sync_default(self):
         """Test triggering sync with default options."""

--- a/tests/unit/test_api_client.py
+++ b/tests/unit/test_api_client.py
@@ -51,8 +51,12 @@ class TestLeggenAPIClient:
         with requests_mock.Mocker() as m:
             m.post("http://localhost:8000/api/v1/banks/callback", json=api_response)
 
-            result = client.exchange_auth_code("test-code")
+            result = client.exchange_auth_code("test-code", "test-state")
             assert result["session_id"] == "sess-123"
+
+            # The server requires both fields to redeem the session
+            request_body = m.last_request.json()
+            assert request_body == {"code": "test-code", "state": "test-state"}
 
     def test_get_accounts_success(self, sample_account_data):
         """Test getting accounts via API client."""

--- a/tests/unit/test_api_sync.py
+++ b/tests/unit/test_api_sync.py
@@ -1,6 +1,5 @@
 """Tests for the sync API route and per-account sync filtering."""
 
-import copy
 import tomllib
 from datetime import datetime, timezone
 from pathlib import Path
@@ -133,27 +132,30 @@ class TestSyncAPI:
         assert response.json()["detail"] == "Failed to run sync."
 
 
-@pytest.fixture
-def restore_config():
-    """Snapshot the global test config (memory + disk) and restore it after.
-
-    Other tests leave stale state on the config singleton, so reload from
-    the canonical test config file (LEGGEN_CONFIG_FILE, set in conftest)
-    before snapshotting.
-    """
-    original_config = copy.deepcopy(config_singleton._config)
-    original_path = config_singleton._config_path
+def _reset_config_singleton() -> None:
+    """Clear the singleton so the next access reloads from
+    LEGGEN_CONFIG_FILE (the canonical test config set in conftest)."""
     config_singleton._config = None
     config_singleton._config_model = None
     config_singleton._config_path = None
+
+
+@pytest.fixture
+def restore_config():
+    """Load the canonical test config, snapshot the file, and leave the
+    singleton clean afterwards.
+
+    Other tests leave stale state on the config singleton, so reset before
+    loading — and reset again on teardown (rather than restoring the
+    possibly-stale snapshot) so later tests start clean too.
+    """
+    _reset_config_singleton()
     config_singleton.load_config()
     config_path = Path(config_singleton._config_path)
     original_bytes = config_path.read_bytes()
     yield config_singleton
     config_path.write_bytes(original_bytes)
-    config_singleton._config = original_config
-    config_singleton._config_model = None
-    config_singleton._config_path = original_path
+    _reset_config_singleton()
 
 
 @pytest.mark.api

--- a/tests/unit/test_api_sync.py
+++ b/tests/unit/test_api_sync.py
@@ -1,6 +1,9 @@
 """Tests for the sync API route and per-account sync filtering."""
 
+import copy
+import tomllib
 from datetime import datetime, timezone
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -9,6 +12,7 @@ from leggen.api.models.sync import SyncResult
 from leggen.background.scheduler import scheduler
 from leggen.repositories import AccountRepository
 from leggen.services.sync_service import SyncAlreadyRunningError, SyncService
+from leggen.utils.config import config as config_singleton
 
 
 def _sync_result() -> SyncResult:
@@ -127,6 +131,53 @@ class TestSyncAPI:
 
         assert response.status_code == 500
         assert response.json()["detail"] == "Failed to run sync."
+
+
+@pytest.fixture
+def restore_config():
+    """Snapshot the global test config (memory + disk) and restore it after."""
+    # Loading via the property ensures _config_path is resolved
+    config_singleton.load_config()
+    config_path = Path(config_singleton._config_path)
+    original_bytes = config_path.read_bytes()
+    original_config = copy.deepcopy(config_singleton._config)
+    yield config_singleton
+    config_path.write_bytes(original_bytes)
+    config_singleton._config = original_config
+    config_singleton._config_model = None
+
+
+@pytest.mark.api
+class TestSyncScheduleAPI:
+    """Test PUT /sync/schedule config handling."""
+
+    def test_update_sync_schedule_preserves_backup_schedule(
+        self, api_client, restore_config
+    ):
+        """Updating the sync schedule must not reset scheduler.backup
+        to defaults (regression: update_section replaced the whole section)."""
+        custom_backup = {"enabled": False, "hour": 12, "minute": 30}
+        scheduler_section = dict(restore_config.scheduler_config)
+        scheduler_section["backup"] = custom_backup
+        restore_config.update_section("scheduler", scheduler_section)
+
+        response = api_client.put(
+            "/api/v1/sync/schedule", json={"enabled": True, "hour": 5, "minute": 15}
+        )
+
+        assert response.status_code == 200
+        assert response.json()["hour"] == 5
+
+        backup = restore_config.scheduler_config["backup"]
+        assert backup["enabled"] is False
+        assert backup["hour"] == 12
+        assert backup["minute"] == 30
+
+        # The surviving backup schedule must also be on disk
+        with open(restore_config._config_path, "rb") as f:
+            on_disk = tomllib.load(f)
+        assert on_disk["scheduler"]["backup"] == custom_backup
+        assert on_disk["scheduler"]["sync"]["hour"] == 5
 
 
 @pytest.mark.unit

--- a/tests/unit/test_api_sync.py
+++ b/tests/unit/test_api_sync.py
@@ -135,16 +135,25 @@ class TestSyncAPI:
 
 @pytest.fixture
 def restore_config():
-    """Snapshot the global test config (memory + disk) and restore it after."""
-    # Loading via the property ensures _config_path is resolved
+    """Snapshot the global test config (memory + disk) and restore it after.
+
+    Other tests leave stale state on the config singleton, so reload from
+    the canonical test config file (LEGGEN_CONFIG_FILE, set in conftest)
+    before snapshotting.
+    """
+    original_config = copy.deepcopy(config_singleton._config)
+    original_path = config_singleton._config_path
+    config_singleton._config = None
+    config_singleton._config_model = None
+    config_singleton._config_path = None
     config_singleton.load_config()
     config_path = Path(config_singleton._config_path)
     original_bytes = config_path.read_bytes()
-    original_config = copy.deepcopy(config_singleton._config)
     yield config_singleton
     config_path.write_bytes(original_bytes)
     config_singleton._config = original_config
     config_singleton._config_model = None
+    config_singleton._config_path = original_path
 
 
 @pytest.mark.api

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -65,7 +65,8 @@ class TestErrorExitCodes:
             )
             result = runner.invoke(cli, command)
         assert result.exit_code == 1
-        assert "Could not connect" in result.output
+        # ClickException output must land on stderr, not stdout
+        assert "Could not connect" in result.stderr
 
     def test_http_error_exits_nonzero(self):
         runner = CliRunner()
@@ -77,7 +78,8 @@ class TestErrorExitCodes:
             )
             result = runner.invoke(cli, ["status"])
         assert result.exit_code == 1
-        assert "Internal server error" in result.output
+        # ClickException output must land on stderr, not stdout
+        assert "Internal server error" in result.stderr
 
 
 def _run_cli_without_config(args, tmp_path, input=None):

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 
 import pytest
+import requests
+import requests_mock
 from click.testing import CliRunner
 
 from leggen.main import cli
@@ -43,6 +45,39 @@ class TestCommandDiscovery:
         assert result.exit_code == 0
         for command in ("balances", "server", "status", "sync", "transactions"):
             assert command in result.output
+
+
+@pytest.mark.cli
+class TestErrorExitCodes:
+    """API failures must exit non-zero with the error on stderr
+    (regression: error paths used to echo-and-return with exit code 0)."""
+
+    @pytest.mark.parametrize(
+        "command", [["status"], ["balances"], ["sync"], ["transactions"]]
+    )
+    def test_unreachable_server_exits_nonzero(self, command):
+        runner = CliRunner()
+        with requests_mock.Mocker() as m:
+            m.register_uri(
+                requests_mock.ANY,
+                requests_mock.ANY,
+                exc=requests.exceptions.ConnectionError,
+            )
+            result = runner.invoke(cli, command)
+        assert result.exit_code == 1
+        assert "Could not connect" in result.output
+
+    def test_http_error_exits_nonzero(self):
+        runner = CliRunner()
+        with requests_mock.Mocker() as m:
+            m.get(
+                requests_mock.ANY,
+                status_code=500,
+                json={"detail": "Internal server error"},
+            )
+            result = runner.invoke(cli, ["status"])
+        assert result.exit_code == 1
+        assert "Internal server error" in result.output
 
 
 def _run_cli_without_config(args, tmp_path, input=None):


### PR DESCRIPTION
Three isolated fixes from the polish review, one commit each:

**1. `PUT /sync/schedule` no longer wipes the backup schedule**
`config.update_section("scheduler", …)` replaced the entire section, so a customized backup schedule was reset to defaults (`enabled=true, hour=4`) on every sync-schedule update. Now merges into the existing section. Includes a regression test verified to fail without the fix (asserts both in-memory and on-disk state).

**2. CLI errors exit non-zero**
Every failure path used to `echo` and `return`, exiting 0 — a failed sync in cron was indistinguishable from success. `LeggenAPIError` now subclasses `ClickException` (message to stderr, exit code 1). Along the way:
- `LeggenAPIClient.from_context(ctx)` replaces the 5-line construction copy-pasted in six commands
- Dropped the redundant pre-flight `health_check()` round-trip in every command (and the now-unused method)
- Errors are printed once instead of twice; `bank delete` no longer dumps a raw traceback on HTTP errors
- Removed the client's `LEGGEN_API_URL` env fallback — the Click option in `main.py` already resolves it
- New tests cover exit codes for connection errors and HTTP errors across four commands (also fixes `test_health_check_failure`, which mocked the wrong URL and never exercised its intended path)

**3. EnableBanking service is app-scoped**
A bare `Depends()` created a fresh service per request, leaking an unclosed `httpx.AsyncClient` each time and defeating the JWT and ASPSP caches (every `GET /banks/institutions` re-signed an RS256 JWT and re-fetched the full ASPSP list upstream). Routes now share one instance via `get_enablebanking_service`, closed in the lifespan shutdown.

Full suite passes.

PR 2 of the polish series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)