### PR TITLE
refactor(api): Backend cleanup — trust global handlers, SQL aggregation, typed responses.

### DIFF
--- a/frontend/src/components/analytics/BalanceChart.tsx
+++ b/frontend/src/components/analytics/BalanceChart.tsx
@@ -77,6 +77,12 @@ export default function BalanceChart({
   // Backend already picks the best balance type per account, so no client-side type filtering needed
   const chartData = data
     .filter((balance) => (balance.currency || currency) === currency)
+    .filter(
+      (
+        balance,
+      ): balance is Balance & { reference_date: string; balance_amount: number } =>
+        balance.reference_date !== null && balance.balance_amount !== null,
+    )
     .map((balance) => ({
       date: new Date(balance.reference_date).toLocaleDateString("en-GB"), // DD/MM/YYYY format
       balance: balance.balance_amount,

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -93,12 +93,12 @@ export interface Transaction {
 export interface Balance {
   id: string;
   account_id: string;
-  balance_amount: number;
+  balance_amount: number | null;
   balance_type: string;
-  currency: string;
-  reference_date: string;
-  created_at: string;
-  updated_at: string;
+  currency: string | null;
+  reference_date: string | null;
+  created_at: string | null;
+  updated_at: string | null;
 }
 
 export interface Bank {

--- a/leggen/api/models/accounts.py
+++ b/leggen/api/models/accounts.py
@@ -40,7 +40,9 @@ class Balance(BaseModel):
 
     id: str
     account_id: str
-    balance_amount: float
+    # Nullable: history points derive from the balances table, whose amount
+    # column legacy rows may hold as NULL.
+    balance_amount: Optional[float] = None
     balance_type: str
     currency: Optional[str] = None
     reference_date: Optional[str] = None

--- a/leggen/api/models/accounts.py
+++ b/leggen/api/models/accounts.py
@@ -35,6 +35,19 @@ class AccountUpdate(BaseModel):
     display_name: Optional[str] = None
 
 
+class Balance(BaseModel):
+    """A single balance entry as returned by /balances and /balances/history"""
+
+    id: str
+    account_id: str
+    balance_amount: float
+    balance_type: str
+    currency: Optional[str] = None
+    reference_date: Optional[str] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+
 class Transaction(BaseModel):
     """Transaction model"""
 

--- a/leggen/api/models/backup.py
+++ b/leggen/api/models/backup.py
@@ -32,6 +32,14 @@ class BackupTest(BaseModel):
     config: S3Config = Field(..., description="S3 configuration to test")
 
 
+class BackupInfo(BaseModel):
+    """Metadata of one stored backup"""
+
+    key: str
+    last_modified: str
+    size: int
+
+
 class BackupOperation(BaseModel):
     """Backup operation request model."""
 

--- a/leggen/api/models/banks.py
+++ b/leggen/api/models/banks.py
@@ -37,6 +37,13 @@ class BankCallbackRequest(BaseModel):
     state: str
 
 
+class Country(BaseModel):
+    """A supported country"""
+
+    code: str
+    name: str
+
+
 class BankConnectionStatus(BaseModel):
     """Bank connection status response"""
 

--- a/leggen/api/models/common.py
+++ b/leggen/api/models/common.py
@@ -17,6 +17,14 @@ class PaginatedResponse(BaseModel, Generic[T]):
     has_prev: bool
 
 
+class HealthStatus(BaseModel):
+    """Response of the healthy path of /health"""
+
+    status: str
+    config_loaded: bool
+    version: str
+
+
 class ErrorField(BaseModel):
     """One field-level validation problem."""
 

--- a/leggen/api/models/notifications.py
+++ b/leggen/api/models/notifications.py
@@ -29,6 +29,15 @@ class NotificationFilters(BaseModel):
     case_sensitive: Optional[List[str]] = None
 
 
+class NotificationServiceStatus(BaseModel):
+    """Availability and configuration state of one notification service"""
+
+    name: str
+    enabled: bool
+    configured: bool
+    active: bool
+
+
 class NotificationSettings(BaseModel):
     """Complete notification settings
 

--- a/leggen/api/models/stats.py
+++ b/leggen/api/models/stats.py
@@ -1,0 +1,45 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class TransactionStats(BaseModel):
+    """Aggregate totals for a filtered set of transactions.
+
+    Money totals cover only the dominant currency of the set (summing across
+    currencies is meaningless); counts cover every matching transaction.
+    """
+
+    date_from: str
+    date_to: str
+    total_transactions: int
+    booked_transactions: int
+    pending_transactions: int
+    currency: Optional[str] = None
+    total_income: float
+    total_expenses: float
+    net_change: float
+    average_transaction: float
+    accounts_included: int
+
+
+class MonthlyStats(BaseModel):
+    """Income/expense totals for one month"""
+
+    month: str
+    income: float
+    expenses: float
+    net: float
+    currency: Optional[str] = None
+
+
+class CategoryStats(BaseModel):
+    """Income/expense totals for one category"""
+
+    category_id: Optional[int] = None
+    category_name: str
+    category_color: str
+    transaction_count: int
+    income: float
+    expenses: float
+    currency: Optional[str] = None

--- a/leggen/api/routes/accounts.py
+++ b/leggen/api/routes/accounts.py
@@ -1,7 +1,8 @@
-from collections import defaultdict
-from typing import Annotated, Any, Dict, List, Optional
+from typing import Annotated, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from loguru import logger
+from pydantic import ValidationError
 
 from leggen.api.models.accounts import (
     AccountBalance,
@@ -16,48 +17,45 @@ from leggen.utils.paths import path_manager
 router = APIRouter()
 
 
-def _latest_balances_by_account(
-    balance_repo: BalanceRepository,
-) -> Dict[str, List[Dict[str, Any]]]:
-    """Fetch the latest balances for every account in one query."""
-    grouped: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
-    for balance in balance_repo.get_balances():
-        grouped[balance["account_id"]].append(balance)
-    return grouped
-
-
 @router.get("/accounts")
 async def get_all_accounts(
     account_repo: Annotated[AccountRepository, Depends()],
     balance_repo: Annotated[BalanceRepository, Depends()],
 ) -> List[AccountDetails]:
     """Get all connected accounts from database"""
-    balances_by_account = _latest_balances_by_account(balance_repo)
+    balances_by_account = balance_repo.get_latest_balances_by_account()
 
-    return [
-        AccountDetails(
-            id=db_account["id"],
-            institution_id=db_account["institution_id"],
-            status=db_account["status"],
-            iban=db_account.get("iban"),
-            name=db_account.get("name"),
-            display_name=db_account.get("display_name"),
-            currency=db_account.get("currency"),
-            logo=db_account.get("logo"),
-            created=db_account["created"],
-            last_accessed=db_account.get("last_accessed"),
-            balances=[
-                AccountBalance(
-                    amount=balance["amount"],
-                    currency=balance["currency"],
-                    balance_type=balance["type"],
-                    last_change_date=balance.get("timestamp"),
+    accounts = []
+    for db_account in account_repo.get_accounts():
+        try:
+            accounts.append(
+                AccountDetails(
+                    id=db_account["id"],
+                    institution_id=db_account["institution_id"],
+                    status=db_account["status"],
+                    iban=db_account.get("iban"),
+                    name=db_account.get("name"),
+                    display_name=db_account.get("display_name"),
+                    currency=db_account.get("currency"),
+                    logo=db_account.get("logo"),
+                    created=db_account["created"],
+                    last_accessed=db_account.get("last_accessed"),
+                    balances=[
+                        AccountBalance(
+                            amount=balance["amount"],
+                            currency=balance["currency"],
+                            balance_type=balance["type"],
+                            last_change_date=balance.get("timestamp"),
+                        )
+                        for balance in balances_by_account.get(db_account["id"], [])
+                    ],
                 )
-                for balance in balances_by_account.get(db_account["id"], [])
-            ],
-        )
-        for db_account in account_repo.get_accounts()
-    ]
+            )
+        except (ValidationError, KeyError) as e:
+            # One malformed legacy row must not empty the whole account list
+            logger.warning(f"Skipping malformed account {db_account.get('id')}: {e}")
+
+    return accounts
 
 
 @router.get("/balances")
@@ -66,7 +64,7 @@ async def get_all_balances(
     balance_repo: Annotated[BalanceRepository, Depends()],
 ) -> List[Balance]:
     """Get all balances from all accounts in database"""
-    balances_by_account = _latest_balances_by_account(balance_repo)
+    balances_by_account = balance_repo.get_latest_balances_by_account()
 
     all_balances = []
     for db_account in account_repo.get_accounts():
@@ -89,20 +87,21 @@ async def get_all_balances(
     return all_balances
 
 
-@router.get("/balances/history")
+@router.get("/balances/history", response_model=List[Balance])
 async def get_historical_balances(
     date_from: str = Query(description="Start date (YYYY-MM-DD)"),
     date_to: str = Query(description="End date (YYYY-MM-DD)"),
     account_id: Optional[str] = Query(
         default=None, description="Filter by specific account ID"
     ),
-) -> List[Balance]:
+) -> list[dict]:
     """Get historical balance progression calculated from transaction history"""
+    # Returned as dicts; the response_model performs the single validation
+    # pass (this is the largest payload the API serves).
     db_path = path_manager.get_database_path()
-    historical_balances = calculate_historical_balances(
+    return calculate_historical_balances(
         db_path, account_id=account_id, date_from=date_from, date_to=date_to
     )
-    return [Balance(**entry) for entry in historical_balances]
 
 
 @router.delete("/accounts/{account_id}")

--- a/leggen/api/routes/accounts.py
+++ b/leggen/api/routes/accounts.py
@@ -1,17 +1,29 @@
-from typing import Annotated, List, Optional
+from collections import defaultdict
+from typing import Annotated, Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from loguru import logger
 
 from leggen.api.models.accounts import (
     AccountBalance,
     AccountDetails,
     AccountUpdate,
+    Balance,
 )
 from leggen.repositories import AccountRepository, BalanceRepository
 from leggen.services.data_processors import calculate_historical_balances
+from leggen.utils.paths import path_manager
 
 router = APIRouter()
+
+
+def _latest_balances_by_account(
+    balance_repo: BalanceRepository,
+) -> Dict[str, List[Dict[str, Any]]]:
+    """Fetch the latest balances for every account in one query."""
+    grouped: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    for balance in balance_repo.get_balances():
+        grouped[balance["account_id"]].append(balance)
+    return grouped
 
 
 @router.get("/accounts")
@@ -20,102 +32,61 @@ async def get_all_accounts(
     balance_repo: Annotated[BalanceRepository, Depends()],
 ) -> List[AccountDetails]:
     """Get all connected accounts from database"""
-    try:
-        accounts = []
+    balances_by_account = _latest_balances_by_account(balance_repo)
 
-        # Get all account details from database
-        db_accounts = account_repo.get_accounts()
-
-        # Process accounts found in database
-        for db_account in db_accounts:
-            try:
-                # Get latest balances from database for this account
-                balances_data = balance_repo.get_balances(db_account["id"])
-
-                # Process balances
-                balances = []
-                for balance in balances_data:
-                    balances.append(
-                        AccountBalance(
-                            amount=balance["amount"],
-                            currency=balance["currency"],
-                            balance_type=balance["type"],
-                            last_change_date=balance.get("timestamp"),
-                        )
-                    )
-
-                accounts.append(
-                    AccountDetails(
-                        id=db_account["id"],
-                        institution_id=db_account["institution_id"],
-                        status=db_account["status"],
-                        iban=db_account.get("iban"),
-                        name=db_account.get("name"),
-                        display_name=db_account.get("display_name"),
-                        currency=db_account.get("currency"),
-                        logo=db_account.get("logo"),
-                        created=db_account["created"],
-                        last_accessed=db_account.get("last_accessed"),
-                        balances=balances,
-                    )
+    return [
+        AccountDetails(
+            id=db_account["id"],
+            institution_id=db_account["institution_id"],
+            status=db_account["status"],
+            iban=db_account.get("iban"),
+            name=db_account.get("name"),
+            display_name=db_account.get("display_name"),
+            currency=db_account.get("currency"),
+            logo=db_account.get("logo"),
+            created=db_account["created"],
+            last_accessed=db_account.get("last_accessed"),
+            balances=[
+                AccountBalance(
+                    amount=balance["amount"],
+                    currency=balance["currency"],
+                    balance_type=balance["type"],
+                    last_change_date=balance.get("timestamp"),
                 )
-
-            except Exception as e:
-                logger.error(
-                    f"Failed to process database account {db_account['id']}: {e}"
-                )
-                continue
-
-        return accounts
-
-    except Exception as e:
-        logger.error(f"Failed to get accounts: {e}")
-        raise HTTPException(status_code=500, detail="Failed to get accounts.") from e
+                for balance in balances_by_account.get(db_account["id"], [])
+            ],
+        )
+        for db_account in account_repo.get_accounts()
+    ]
 
 
 @router.get("/balances")
 async def get_all_balances(
     account_repo: Annotated[AccountRepository, Depends()],
     balance_repo: Annotated[BalanceRepository, Depends()],
-) -> List[dict]:
+) -> List[Balance]:
     """Get all balances from all accounts in database"""
-    try:
-        # Get all accounts first to iterate through them
-        db_accounts = account_repo.get_accounts()
+    balances_by_account = _latest_balances_by_account(balance_repo)
 
-        all_balances = []
-        for db_account in db_accounts:
-            try:
-                # Get balances for this account
-                db_balances = balance_repo.get_balances(account_id=db_account["id"])
-
-                # Process balances and add account info
-                for balance in db_balances:
-                    balance_data = {
-                        "id": f"{db_account['id']}_{balance['type']}",  # Create unique ID
-                        "account_id": db_account["id"],
-                        "balance_amount": balance["amount"],
-                        "balance_type": balance["type"],
-                        "currency": balance["currency"],
-                        "reference_date": balance.get(
-                            "timestamp", db_account.get("last_accessed")
-                        ),
-                        "created_at": db_account.get("created"),
-                        "updated_at": db_account.get("last_accessed"),
-                    }
-                    all_balances.append(balance_data)
-
-            except Exception as e:
-                logger.error(
-                    f"Failed to get balances for account {db_account['id']}: {e}"
+    all_balances = []
+    for db_account in account_repo.get_accounts():
+        for balance in balances_by_account.get(db_account["id"], []):
+            all_balances.append(
+                Balance(
+                    id=f"{db_account['id']}_{balance['type']}",
+                    account_id=db_account["id"],
+                    balance_amount=balance["amount"],
+                    balance_type=balance["type"],
+                    currency=balance["currency"],
+                    reference_date=balance.get(
+                        "timestamp", db_account.get("last_accessed")
+                    ),
+                    created_at=db_account.get("created"),
+                    updated_at=db_account.get("last_accessed"),
                 )
-                continue
+            )
 
-        return all_balances
-
-    except Exception as e:
-        logger.error(f"Failed to get all balances: {e}")
-        raise HTTPException(status_code=500, detail="Failed to get balances.") from e
+    return all_balances
 
 
 @router.get("/balances/history")
@@ -125,23 +96,13 @@ async def get_historical_balances(
     account_id: Optional[str] = Query(
         default=None, description="Filter by specific account ID"
     ),
-) -> List[dict]:
+) -> List[Balance]:
     """Get historical balance progression calculated from transaction history"""
-    try:
-        from leggen.utils.paths import path_manager
-
-        db_path = path_manager.get_database_path()
-        historical_balances = calculate_historical_balances(
-            db_path, account_id=account_id, date_from=date_from, date_to=date_to
-        )
-
-        return historical_balances
-
-    except Exception as e:
-        logger.error(f"Failed to get historical balances: {e}")
-        raise HTTPException(
-            status_code=500, detail="Failed to get historical balances."
-        ) from e
+    db_path = path_manager.get_database_path()
+    historical_balances = calculate_historical_balances(
+        db_path, account_id=account_id, date_from=date_from, date_to=date_to
+    )
+    return [Balance(**entry) for entry in historical_balances]
 
 
 @router.delete("/accounts/{account_id}")
@@ -166,27 +127,14 @@ async def update_account_details(
     account_repo: Annotated[AccountRepository, Depends()],
 ) -> dict:
     """Update account details (currently only display_name)"""
-    try:
-        # Get current account details
-        current_account = account_repo.get_account(account_id)
+    current_account = account_repo.get_account(account_id)
+    if not current_account:
+        raise HTTPException(status_code=404, detail=f"Account {account_id} not found")
 
-        if not current_account:
-            raise HTTPException(
-                status_code=404, detail=f"Account {account_id} not found"
-            )
+    updated_account_data = current_account.copy()
+    if update_data.display_name is not None:
+        updated_account_data["display_name"] = update_data.display_name
 
-        # Prepare updated account data
-        updated_account_data = current_account.copy()
-        if update_data.display_name is not None:
-            updated_account_data["display_name"] = update_data.display_name
+    account_repo.persist(updated_account_data)
 
-        # Persist updated account details
-        account_repo.persist(updated_account_data)
-
-        return {"id": account_id, "display_name": update_data.display_name}
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Failed to update account {account_id}: {e}")
-        raise HTTPException(status_code=500, detail="Failed to update account.") from e
+    return {"id": account_id, "display_name": update_data.display_name}

--- a/leggen/api/routes/backup.py
+++ b/leggen/api/routes/backup.py
@@ -1,7 +1,6 @@
 """API routes for backup management."""
 
 from fastapi import APIRouter, HTTPException
-from loguru import logger
 
 from leggen.api.models.backup import (
     BackupOperation,
@@ -21,257 +20,203 @@ router = APIRouter()
 @router.get("/backup/settings")
 async def get_backup_settings() -> BackupSettings:
     """Get current backup settings."""
-    try:
-        backup_config = config.backup_config
+    backup_config = config.backup_config
 
-        # Build response safely without exposing secrets
-        s3_config = backup_config.get("s3", {})
+    # Build response safely without exposing secrets
+    s3_config = backup_config.get("s3", {})
 
-        settings = BackupSettings(
-            s3=S3Config(
-                access_key_id=mask_secret(s3_config.get("access_key_id")),
-                secret_access_key=mask_secret(s3_config.get("secret_access_key")),
-                bucket_name=s3_config.get("bucket_name", ""),
-                region=s3_config.get("region", "us-east-1"),
-                endpoint_url=s3_config.get("endpoint_url"),
-                path_style=s3_config.get("path_style", False),
-                enabled=s3_config.get("enabled", True),
-            )
-            if s3_config.get("bucket_name")
-            else None,
+    return BackupSettings(
+        s3=S3Config(
+            access_key_id=mask_secret(s3_config.get("access_key_id")),
+            secret_access_key=mask_secret(s3_config.get("secret_access_key")),
+            bucket_name=s3_config.get("bucket_name", ""),
+            region=s3_config.get("region", "us-east-1"),
+            endpoint_url=s3_config.get("endpoint_url"),
+            path_style=s3_config.get("path_style", False),
+            enabled=s3_config.get("enabled", True),
         )
-
-        return settings
-
-    except Exception as e:
-        logger.error(f"Failed to get backup settings: {e}")
-        raise HTTPException(
-            status_code=500, detail="Failed to get backup settings."
-        ) from e
+        if s3_config.get("bucket_name")
+        else None,
+    )
 
 
 @router.put("/backup/settings")
 async def update_backup_settings(settings: BackupSettings) -> dict:
     """Update backup settings."""
+    if settings.s3 is None:
+        # Reporting success for a request that changes nothing hides the
+        # mistake; removing the configuration has its own endpoint.
+        raise HTTPException(
+            status_code=400,
+            detail="s3 configuration is required. Use DELETE /backup/settings to remove it.",
+        )
+
+    # Clients echo back masked secrets from GET to mean "keep current value"
+    stored_s3 = config.backup_config.get("s3", {})
     try:
-        if settings.s3 is None:
-            # Reporting success for a request that changes nothing hides the
-            # mistake; removing the configuration has its own endpoint.
+        access_key_id = resolve_secret(
+            settings.s3.access_key_id,
+            stored_s3.get("access_key_id"),
+            "S3 access key ID",
+        )
+        secret_access_key = resolve_secret(
+            settings.s3.secret_access_key,
+            stored_s3.get("secret_access_key"),
+            "S3 secret access key",
+        )
+    except MaskedSecretError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+    # Convert API model to config model
+    s3_config = S3BackupConfig(
+        access_key_id=access_key_id,
+        secret_access_key=secret_access_key,
+        bucket_name=settings.s3.bucket_name,
+        region=settings.s3.region,
+        endpoint_url=settings.s3.endpoint_url,
+        path_style=settings.s3.path_style,
+        enabled=settings.s3.enabled,
+    )
+
+    # Test connection, unless the config is being disabled —
+    # turning S3 off must not require working credentials
+    if settings.s3.enabled:
+        backup_service = BackupService()
+        connection_success = await backup_service.test_connection(s3_config)
+
+        if not connection_success:
             raise HTTPException(
                 status_code=400,
-                detail="s3 configuration is required. Use DELETE /backup/settings to remove it.",
+                detail="S3 connection test failed. Please check your configuration.",
             )
 
-        # Clients echo back masked secrets from GET to mean "keep current value"
-        stored_s3 = config.backup_config.get("s3", {})
-        try:
-            access_key_id = resolve_secret(
-                settings.s3.access_key_id,
-                stored_s3.get("access_key_id"),
-                "S3 access key ID",
-            )
-            secret_access_key = resolve_secret(
-                settings.s3.secret_access_key,
-                stored_s3.get("secret_access_key"),
-                "S3 secret access key",
-            )
-        except MaskedSecretError as e:
-            raise HTTPException(status_code=400, detail=str(e)) from e
+    config.update_section(
+        "backup",
+        {
+            "s3": {
+                "access_key_id": access_key_id,
+                "secret_access_key": secret_access_key,
+                "bucket_name": settings.s3.bucket_name,
+                "region": settings.s3.region,
+                "endpoint_url": settings.s3.endpoint_url,
+                "path_style": settings.s3.path_style,
+                "enabled": settings.s3.enabled,
+            }
+        },
+    )
 
-        # Convert API model to config model
-        s3_config = S3BackupConfig(
-            access_key_id=access_key_id,
-            secret_access_key=secret_access_key,
-            bucket_name=settings.s3.bucket_name,
-            region=settings.s3.region,
-            endpoint_url=settings.s3.endpoint_url,
-            path_style=settings.s3.path_style,
-            enabled=settings.s3.enabled,
-        )
-
-        # Test connection, unless the config is being disabled —
-        # turning S3 off must not require working credentials
-        if settings.s3.enabled:
-            backup_service = BackupService()
-            connection_success = await backup_service.test_connection(s3_config)
-
-            if not connection_success:
-                raise HTTPException(
-                    status_code=400,
-                    detail="S3 connection test failed. Please check your configuration.",
-                )
-
-        config.update_section(
-            "backup",
-            {
-                "s3": {
-                    "access_key_id": access_key_id,
-                    "secret_access_key": secret_access_key,
-                    "bucket_name": settings.s3.bucket_name,
-                    "region": settings.s3.region,
-                    "endpoint_url": settings.s3.endpoint_url,
-                    "path_style": settings.s3.path_style,
-                    "enabled": settings.s3.enabled,
-                }
-            },
-        )
-
-        return {"updated": True}
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Failed to update backup settings: {e}")
-        raise HTTPException(
-            status_code=500, detail="Failed to update backup settings."
-        ) from e
+    return {"updated": True}
 
 
 @router.delete("/backup/settings")
 async def delete_backup_settings() -> dict:
     """Remove the S3 backup configuration, including its stored credentials."""
-    try:
-        config.update_section("backup", {})
+    config.update_section("backup", {})
 
-        return {"deleted": "s3"}
-
-    except Exception as e:
-        logger.error(f"Failed to delete backup settings: {e}")
-        raise HTTPException(
-            status_code=500, detail="Failed to delete backup settings."
-        ) from e
+    return {"deleted": "s3"}
 
 
 @router.post("/backup/test")
 async def test_backup_connection(test_request: BackupTest) -> dict:
     """Test backup connection."""
+    if test_request.service != "s3":
+        raise HTTPException(status_code=400, detail="Only 's3' service is supported")
+
+    # Clients may submit masked secrets meaning "test with the stored value"
+    stored_s3 = config.backup_config.get("s3", {})
     try:
-        if test_request.service != "s3":
-            raise HTTPException(
-                status_code=400, detail="Only 's3' service is supported"
-            )
-
-        # Clients may submit masked secrets meaning "test with the stored value"
-        stored_s3 = config.backup_config.get("s3", {})
-        try:
-            access_key_id = resolve_secret(
-                test_request.config.access_key_id,
-                stored_s3.get("access_key_id"),
-                "S3 access key ID",
-            )
-            secret_access_key = resolve_secret(
-                test_request.config.secret_access_key,
-                stored_s3.get("secret_access_key"),
-                "S3 secret access key",
-            )
-        except MaskedSecretError as e:
-            raise HTTPException(status_code=400, detail=str(e)) from e
-
-        # Convert API model to config model
-        s3_config = S3BackupConfig(
-            access_key_id=access_key_id,
-            secret_access_key=secret_access_key,
-            bucket_name=test_request.config.bucket_name,
-            region=test_request.config.region,
-            endpoint_url=test_request.config.endpoint_url,
-            path_style=test_request.config.path_style,
-            enabled=test_request.config.enabled,
+        access_key_id = resolve_secret(
+            test_request.config.access_key_id,
+            stored_s3.get("access_key_id"),
+            "S3 access key ID",
         )
+        secret_access_key = resolve_secret(
+            test_request.config.secret_access_key,
+            stored_s3.get("secret_access_key"),
+            "S3 secret access key",
+        )
+    except MaskedSecretError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
 
-        backup_service = BackupService()
-        success = await backup_service.test_connection(s3_config)
+    # Convert API model to config model
+    s3_config = S3BackupConfig(
+        access_key_id=access_key_id,
+        secret_access_key=secret_access_key,
+        bucket_name=test_request.config.bucket_name,
+        region=test_request.config.region,
+        endpoint_url=test_request.config.endpoint_url,
+        path_style=test_request.config.path_style,
+        enabled=test_request.config.enabled,
+    )
 
-        if not success:
-            raise HTTPException(status_code=400, detail="S3 connection test failed")
+    backup_service = BackupService()
+    success = await backup_service.test_connection(s3_config)
 
-        return {"connected": True}
+    if not success:
+        raise HTTPException(status_code=400, detail="S3 connection test failed")
 
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Failed to test backup connection: {e}")
-        raise HTTPException(
-            status_code=500, detail="Failed to test backup connection."
-        ) from e
+    return {"connected": True}
 
 
 @router.get("/backup/list")
 async def list_backups() -> list:
     """List available backups."""
-    try:
-        backup_config = config.backup_config.get("s3", {})
+    backup_config = config.backup_config.get("s3", {})
 
-        if not backup_config.get("bucket_name"):
-            return []
+    if not backup_config.get("bucket_name"):
+        return []
 
-        # Convert config to model
-        s3_config = S3BackupConfig(**backup_config)
-        backup_service = BackupService(s3_config)
+    # Convert config to model
+    s3_config = S3BackupConfig(**backup_config)
+    backup_service = BackupService(s3_config)
 
-        backups = await backup_service.list_backups()
-
-        return backups
-
-    except Exception as e:
-        logger.error(f"Failed to list backups: {e}")
-        raise HTTPException(status_code=500, detail="Failed to list backups.") from e
+    return await backup_service.list_backups()
 
 
 @router.post("/backup/operation")
 async def backup_operation(operation_request: BackupOperation) -> dict:
     """Perform backup operation (backup or restore)."""
+    backup_config = config.backup_config.get("s3", {})
+
+    if not backup_config.get("bucket_name"):
+        raise HTTPException(status_code=400, detail="S3 backup is not configured")
+
+    # Convert config to model with validation
     try:
-        backup_config = config.backup_config.get("s3", {})
-
-        if not backup_config.get("bucket_name"):
-            raise HTTPException(status_code=400, detail="S3 backup is not configured")
-
-        # Convert config to model with validation
-        try:
-            s3_config = S3BackupConfig(**backup_config)
-        except Exception as e:
-            raise HTTPException(
-                status_code=400, detail="Invalid S3 configuration."
-            ) from e
-
-        backup_service = BackupService(s3_config)
-
-        if operation_request.operation == "backup":
-            # Backup database
-            database_path = path_manager.get_database_path()
-            success = await backup_service.backup_database(database_path)
-
-            if not success:
-                raise HTTPException(status_code=500, detail="Database backup failed")
-
-            return {"operation": "backup", "completed": True}
-
-        elif operation_request.operation == "restore":
-            if not operation_request.backup_key:
-                raise HTTPException(
-                    status_code=400,
-                    detail="backup_key is required for restore operation",
-                )
-
-            # Restore database
-            database_path = path_manager.get_database_path()
-            success = await backup_service.restore_database(
-                operation_request.backup_key, database_path
-            )
-
-            if not success:
-                raise HTTPException(status_code=500, detail="Database restore failed")
-
-            return {"operation": "restore", "completed": True}
-        else:
-            raise HTTPException(
-                status_code=400, detail="Invalid operation. Use 'backup' or 'restore'"
-            )
-
-    except HTTPException:
-        raise
+        s3_config = S3BackupConfig(**backup_config)
     except Exception as e:
-        logger.error(f"Failed to perform backup operation: {e}")
+        raise HTTPException(status_code=400, detail="Invalid S3 configuration.") from e
+
+    backup_service = BackupService(s3_config)
+
+    if operation_request.operation == "backup":
+        # Backup database
+        database_path = path_manager.get_database_path()
+        success = await backup_service.backup_database(database_path)
+
+        if not success:
+            raise HTTPException(status_code=500, detail="Database backup failed")
+
+        return {"operation": "backup", "completed": True}
+
+    elif operation_request.operation == "restore":
+        if not operation_request.backup_key:
+            raise HTTPException(
+                status_code=400,
+                detail="backup_key is required for restore operation",
+            )
+
+        # Restore database
+        database_path = path_manager.get_database_path()
+        success = await backup_service.restore_database(
+            operation_request.backup_key, database_path
+        )
+
+        if not success:
+            raise HTTPException(status_code=500, detail="Database restore failed")
+
+        return {"operation": "restore", "completed": True}
+    else:
         raise HTTPException(
-            status_code=500, detail="Failed to perform backup operation."
-        ) from e
+            status_code=400, detail="Invalid operation. Use 'backup' or 'restore'"
+        )

--- a/leggen/api/routes/backup.py
+++ b/leggen/api/routes/backup.py
@@ -1,8 +1,10 @@
 """API routes for backup management."""
 
 from fastapi import APIRouter, HTTPException
+from pydantic import ValidationError
 
 from leggen.api.models.backup import (
+    BackupInfo,
     BackupOperation,
     BackupSettings,
     BackupTest,
@@ -158,8 +160,8 @@ async def test_backup_connection(test_request: BackupTest) -> dict:
     return {"connected": True}
 
 
-@router.get("/backup/list")
-async def list_backups() -> list:
+@router.get("/backup/list", response_model=list[BackupInfo])
+async def list_backups() -> list[dict]:
     """List available backups."""
     backup_config = config.backup_config.get("s3", {})
 
@@ -184,7 +186,7 @@ async def backup_operation(operation_request: BackupOperation) -> dict:
     # Convert config to model with validation
     try:
         s3_config = S3BackupConfig(**backup_config)
-    except Exception as e:
+    except ValidationError as e:
         raise HTTPException(status_code=400, detail="Invalid S3 configuration.") from e
 
     backup_service = BackupService(s3_config)

--- a/leggen/api/routes/banks.py
+++ b/leggen/api/routes/banks.py
@@ -9,6 +9,7 @@ from leggen.api.models.banks import (
     BankConnectionRequest,
     BankConnectionStatus,
     BankInstitution,
+    Country,
 )
 from leggen.repositories import SessionRepository
 from leggen.services.enablebanking_service import (
@@ -165,7 +166,7 @@ async def delete_bank_connection(
 
 
 @router.get("/banks/countries")
-async def get_supported_countries() -> list[dict]:
+async def get_supported_countries() -> list[Country]:
     """Get list of supported countries"""
     countries = [
         {"code": "AT", "name": "Austria"},
@@ -201,4 +202,4 @@ async def get_supported_countries() -> list[dict]:
         {"code": "GB", "name": "United Kingdom"},
     ]
 
-    return countries
+    return [Country(**country) for country in countries]

--- a/leggen/api/routes/banks.py
+++ b/leggen/api/routes/banks.py
@@ -2,7 +2,6 @@ from datetime import datetime, timezone
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from loguru import logger
 
 from leggen.api.models.banks import (
     BankAuthResponse,
@@ -28,25 +27,19 @@ async def get_bank_institutions(
     country: str = Query(default="PT", description="Country code (e.g., PT, ES, FR)"),
 ) -> list[BankInstitution]:
     """Get available bank institutions (ASPSPs) for a country"""
-    try:
-        aspsps = await enablebanking_service.get_aspsps(country)
-        institutions = [
-            BankInstitution(
-                name=aspsp["name"],
-                country=aspsp.get("country", country),
-                bic=aspsp.get("bic"),
-                logo=aspsp.get("logo"),
-                psu_types=aspsp.get("psu_types", ["personal"]),
-                maximum_consent_validity=aspsp.get("maximum_consent_validity"),
-            )
-            for aspsp in aspsps
-        ]
-        return sorted(institutions, key=lambda institution: institution.name.casefold())
-    except Exception as e:
-        logger.error(f"Failed to get institutions for {country}: {e}")
-        raise HTTPException(
-            status_code=500, detail="Failed to get institutions."
-        ) from e
+    aspsps = await enablebanking_service.get_aspsps(country)
+    institutions = [
+        BankInstitution(
+            name=aspsp["name"],
+            country=aspsp.get("country", country),
+            bic=aspsp.get("bic"),
+            logo=aspsp.get("logo"),
+            psu_types=aspsp.get("psu_types", ["personal"]),
+            maximum_consent_validity=aspsp.get("maximum_consent_validity"),
+        )
+        for aspsp in aspsps
+    ]
+    return sorted(institutions, key=lambda institution: institution.name.casefold())
 
 
 @router.post("/banks/connect")
@@ -57,33 +50,27 @@ async def connect_to_bank(
     ],
 ) -> BankAuthResponse:
     """Start bank authorization flow"""
-    try:
-        redirect_url = request.redirect_url or "http://localhost:8000/"
+    redirect_url = request.redirect_url or "http://localhost:8000/"
 
-        # Ask for the longest consent the bank supports; start_auth falls back
-        # to 90 days when the ASPSP doesn't report a maximum.
-        maximum_consent_validity = None
-        aspsps = await enablebanking_service.get_aspsps(request.aspsp_country)
-        for aspsp in aspsps:
-            if aspsp.get("name") == request.aspsp_name:
-                validity = aspsp.get("maximum_consent_validity")
-                if validity:
-                    maximum_consent_validity = int(validity)
-                break
+    # Ask for the longest consent the bank supports; start_auth falls back
+    # to 90 days when the ASPSP doesn't report a maximum.
+    maximum_consent_validity = None
+    aspsps = await enablebanking_service.get_aspsps(request.aspsp_country)
+    for aspsp in aspsps:
+        if aspsp.get("name") == request.aspsp_name:
+            validity = aspsp.get("maximum_consent_validity")
+            if validity:
+                maximum_consent_validity = int(validity)
+            break
 
-        result = await enablebanking_service.start_auth(
-            aspsp_name=request.aspsp_name,
-            aspsp_country=request.aspsp_country,
-            redirect_url=redirect_url,
-            psu_type=request.psu_type,
-            maximum_consent_validity=maximum_consent_validity,
-        )
-        return BankAuthResponse(url=result["url"])
-    except Exception as e:
-        logger.error(
-            f"Failed to start auth for {request.aspsp_name} ({request.aspsp_country}): {e}"
-        )
-        raise HTTPException(status_code=500, detail="Failed to connect to bank.") from e
+    result = await enablebanking_service.start_auth(
+        aspsp_name=request.aspsp_name,
+        aspsp_country=request.aspsp_country,
+        redirect_url=redirect_url,
+        psu_type=request.psu_type,
+        maximum_consent_validity=maximum_consent_validity,
+    )
+    return BankAuthResponse(url=result["url"])
 
 
 @router.post("/banks/callback")
@@ -101,27 +88,23 @@ async def bank_auth_callback(
             detail="Unknown or expired authorization state. Restart the bank connection flow.",
         )
 
-    try:
-        session_data = await enablebanking_service.create_session(request.code)
+    session_data = await enablebanking_service.create_session(request.code)
 
-        # Store session locally
-        aspsp = session_data.get("aspsp", {})
-        access = session_data.get("access", {})
-        session_record = {
-            "session_id": session_data["session_id"],
-            "aspsp_name": aspsp.get("name", ""),
-            "aspsp_country": aspsp.get("country", ""),
-            "accounts": session_data.get("accounts"),
-            "valid_until": access.get("valid_until"),
-            "created_at": datetime.now(timezone.utc).isoformat(),
-            "status": "active",
-        }
-        session_repo.persist(session_record)
+    # Store session locally
+    aspsp = session_data.get("aspsp", {})
+    access = session_data.get("access", {})
+    session_record = {
+        "session_id": session_data["session_id"],
+        "aspsp_name": aspsp.get("name", ""),
+        "aspsp_country": aspsp.get("country", ""),
+        "accounts": session_data.get("accounts"),
+        "valid_until": access.get("valid_until"),
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "status": "active",
+    }
+    session_repo.persist(session_record)
 
-        return session_record
-    except Exception as e:
-        logger.error(f"Failed to exchange auth code: {e}")
-        raise HTTPException(status_code=500, detail="Failed to create session.") from e
+    return session_record
 
 
 @router.get("/banks/status")
@@ -129,48 +112,44 @@ async def get_bank_connections_status(
     session_repo: Annotated[SessionRepository, Depends()],
 ) -> list[BankConnectionStatus]:
     """Get status of all bank connections"""
-    try:
-        sessions = session_repo.get_sessions()
-        connections = []
-        now = datetime.now(timezone.utc)
+    sessions = session_repo.get_sessions()
+    connections = []
+    now = datetime.now(timezone.utc)
 
-        for session in sessions:
-            # Determine status based on valid_until
-            status = session.get("status", "active")
-            valid_until_str = session.get("valid_until")
-            days_until_expiry = None
-            if valid_until_str and status == "active":
-                try:
-                    valid_until = datetime.fromisoformat(valid_until_str)
-                    # Timestamps stored without an offset are UTC
-                    if valid_until.tzinfo is None:
-                        valid_until = valid_until.replace(tzinfo=timezone.utc)
-                    days_until_expiry = (valid_until - now).days
-                    if valid_until < now:
-                        status = "expired"
-                        days_until_expiry = None
-                except (ValueError, TypeError):
-                    pass
+    for session in sessions:
+        # Determine status based on valid_until
+        status = session.get("status", "active")
+        valid_until_str = session.get("valid_until")
+        days_until_expiry = None
+        if valid_until_str and status == "active":
+            try:
+                valid_until = datetime.fromisoformat(valid_until_str)
+                # Timestamps stored without an offset are UTC
+                if valid_until.tzinfo is None:
+                    valid_until = valid_until.replace(tzinfo=timezone.utc)
+                days_until_expiry = (valid_until - now).days
+                if valid_until < now:
+                    status = "expired"
+                    days_until_expiry = None
+            except (ValueError, TypeError):
+                pass
 
-            accounts = session.get("accounts", []) or []
+        accounts = session.get("accounts", []) or []
 
-            connections.append(
-                BankConnectionStatus(
-                    session_id=session["session_id"],
-                    aspsp_name=session["aspsp_name"],
-                    aspsp_country=session["aspsp_country"],
-                    accounts_count=len(accounts),
-                    created_at=session["created_at"],
-                    valid_until=valid_until_str,
-                    status=status,
-                    days_until_expiry=days_until_expiry,
-                )
+        connections.append(
+            BankConnectionStatus(
+                session_id=session["session_id"],
+                aspsp_name=session["aspsp_name"],
+                aspsp_country=session["aspsp_country"],
+                accounts_count=len(accounts),
+                created_at=session["created_at"],
+                valid_until=valid_until_str,
+                status=status,
+                days_until_expiry=days_until_expiry,
             )
+        )
 
-        return connections
-    except Exception as e:
-        logger.error(f"Failed to get bank connection status: {e}")
-        raise HTTPException(status_code=500, detail="Failed to get bank status.") from e
+    return connections
 
 
 @router.delete("/banks/connections/{session_id}")

--- a/leggen/api/routes/banks.py
+++ b/leggen/api/routes/banks.py
@@ -165,41 +165,42 @@ async def delete_bank_connection(
     return {"deleted": session_id}
 
 
+_COUNTRIES = [
+    Country(code="AT", name="Austria"),
+    Country(code="BE", name="Belgium"),
+    Country(code="BG", name="Bulgaria"),
+    Country(code="HR", name="Croatia"),
+    Country(code="CY", name="Cyprus"),
+    Country(code="CZ", name="Czech Republic"),
+    Country(code="DK", name="Denmark"),
+    Country(code="EE", name="Estonia"),
+    Country(code="FI", name="Finland"),
+    Country(code="FR", name="France"),
+    Country(code="DE", name="Germany"),
+    Country(code="GR", name="Greece"),
+    Country(code="HU", name="Hungary"),
+    Country(code="IS", name="Iceland"),
+    Country(code="IE", name="Ireland"),
+    Country(code="IT", name="Italy"),
+    Country(code="LV", name="Latvia"),
+    Country(code="LI", name="Liechtenstein"),
+    Country(code="LT", name="Lithuania"),
+    Country(code="LU", name="Luxembourg"),
+    Country(code="MT", name="Malta"),
+    Country(code="NL", name="Netherlands"),
+    Country(code="NO", name="Norway"),
+    Country(code="PL", name="Poland"),
+    Country(code="PT", name="Portugal"),
+    Country(code="RO", name="Romania"),
+    Country(code="SK", name="Slovakia"),
+    Country(code="SI", name="Slovenia"),
+    Country(code="ES", name="Spain"),
+    Country(code="SE", name="Sweden"),
+    Country(code="GB", name="United Kingdom"),
+]
+
+
 @router.get("/banks/countries")
 async def get_supported_countries() -> list[Country]:
     """Get list of supported countries"""
-    countries = [
-        {"code": "AT", "name": "Austria"},
-        {"code": "BE", "name": "Belgium"},
-        {"code": "BG", "name": "Bulgaria"},
-        {"code": "HR", "name": "Croatia"},
-        {"code": "CY", "name": "Cyprus"},
-        {"code": "CZ", "name": "Czech Republic"},
-        {"code": "DK", "name": "Denmark"},
-        {"code": "EE", "name": "Estonia"},
-        {"code": "FI", "name": "Finland"},
-        {"code": "FR", "name": "France"},
-        {"code": "DE", "name": "Germany"},
-        {"code": "GR", "name": "Greece"},
-        {"code": "HU", "name": "Hungary"},
-        {"code": "IS", "name": "Iceland"},
-        {"code": "IE", "name": "Ireland"},
-        {"code": "IT", "name": "Italy"},
-        {"code": "LV", "name": "Latvia"},
-        {"code": "LI", "name": "Liechtenstein"},
-        {"code": "LT", "name": "Lithuania"},
-        {"code": "LU", "name": "Luxembourg"},
-        {"code": "MT", "name": "Malta"},
-        {"code": "NL", "name": "Netherlands"},
-        {"code": "NO", "name": "Norway"},
-        {"code": "PL", "name": "Poland"},
-        {"code": "PT", "name": "Portugal"},
-        {"code": "RO", "name": "Romania"},
-        {"code": "SK", "name": "Slovakia"},
-        {"code": "SI", "name": "Slovenia"},
-        {"code": "ES", "name": "Spain"},
-        {"code": "SE", "name": "Sweden"},
-        {"code": "GB", "name": "United Kingdom"},
-    ]
-
-    return [Country(**country) for country in countries]
+    return _COUNTRIES

--- a/leggen/api/routes/categories.py
+++ b/leggen/api/routes/categories.py
@@ -3,7 +3,6 @@
 from typing import Annotated, Any, Dict
 
 from fastapi import APIRouter, Depends, HTTPException
-from loguru import logger
 
 from leggen.api.models.categories import (
     BulkCategoryAssignment,
@@ -44,12 +43,8 @@ async def get_categories(
     category_repo: Annotated[CategoryRepository, Depends()],
 ) -> list[Category]:
     """Get all categories."""
-    try:
-        categories = category_repo.get_all_categories()
-        return [Category(**cat) for cat in categories]
-    except Exception as e:
-        logger.error(f"Failed to get categories: {e}")
-        raise HTTPException(status_code=500, detail="Failed to get categories.") from e
+    categories = category_repo.get_all_categories()
+    return [Category(**cat) for cat in categories]
 
 
 @router.post("/categories", response_model=Category, status_code=201)
@@ -78,22 +73,16 @@ async def update_category(
     category_repo: Annotated[CategoryRepository, Depends()],
 ) -> Category:
     """Update a category."""
-    try:
-        cat = category_repo.update_category(
-            category_id=category_id,
-            name=body.name,
-            color=body.color,
-            icon=body.icon,
-            exclude_from_stats=body.exclude_from_stats,
-        )
-        if not cat:
-            raise HTTPException(status_code=404, detail="Category not found.")
-        return Category(**cat)
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Failed to update category: {e}")
-        raise HTTPException(status_code=500, detail="Failed to update category.") from e
+    cat = category_repo.update_category(
+        category_id=category_id,
+        name=body.name,
+        color=body.color,
+        icon=body.icon,
+        exclude_from_stats=body.exclude_from_stats,
+    )
+    if not cat:
+        raise HTTPException(status_code=404, detail="Category not found.")
+    return Category(**cat)
 
 
 @router.delete("/categories/{category_id}", status_code=204)
@@ -102,18 +91,12 @@ async def delete_category(
     category_repo: Annotated[CategoryRepository, Depends()],
 ) -> None:
     """Delete a custom category."""
-    try:
-        deleted = category_repo.delete_category(category_id)
-        if not deleted:
-            raise HTTPException(
-                status_code=400,
-                detail="Category not found or is a default category.",
-            )
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Failed to delete category: {e}")
-        raise HTTPException(status_code=500, detail="Failed to delete category.") from e
+    deleted = category_repo.delete_category(category_id)
+    if not deleted:
+        raise HTTPException(
+            status_code=400,
+            detail="Category not found or is a default category.",
+        )
 
 
 # --- Transaction category assignment ---
@@ -125,23 +108,15 @@ async def bulk_categorize_transactions(
     category_repo: Annotated[CategoryRepository, Depends()],
 ) -> dict[str, Any]:
     """Assign a category to all transactions matching a description."""
-    try:
-        cat = category_repo.get_category_by_id(body.category_id)
-        if not cat:
-            raise HTTPException(status_code=404, detail="Category not found.")
+    cat = category_repo.get_category_by_id(body.category_id)
+    if not cat:
+        raise HTTPException(status_code=404, detail="Category not found.")
 
-        updated_count = category_repo.bulk_assign_by_description(
-            category_id=body.category_id,
-            description=body.description,
-        )
-        return {"status": "ok", "updated_count": updated_count}
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Failed to bulk categorize transactions: {e}")
-        raise HTTPException(
-            status_code=500, detail="Failed to bulk categorize transactions."
-        ) from e
+    updated_count = category_repo.bulk_assign_by_description(
+        category_id=body.category_id,
+        description=body.description,
+    )
+    return {"status": "ok", "updated_count": updated_count}
 
 
 @router.delete("/transactions/bulk-categorize")
@@ -150,16 +125,10 @@ async def bulk_remove_transaction_categories(
     category_repo: Annotated[CategoryRepository, Depends()],
 ) -> dict[str, Any]:
     """Remove category from all transactions matching a description."""
-    try:
-        removed_count = category_repo.bulk_remove_by_description(
-            description=body.description,
-        )
-        return {"status": "ok", "removed_count": removed_count}
-    except Exception as e:
-        logger.error(f"Failed to bulk remove categories: {e}")
-        raise HTTPException(
-            status_code=500, detail="Failed to bulk remove categories."
-        ) from e
+    removed_count = category_repo.bulk_remove_by_description(
+        description=body.description,
+    )
+    return {"status": "ok", "removed_count": removed_count}
 
 
 @router.put("/transactions/{account_id}/{transaction_id}/category")
@@ -171,31 +140,25 @@ async def assign_transaction_category(
     transaction_repo: Annotated[TransactionRepository, Depends()],
 ) -> dict[str, str]:
     """Assign a category to a transaction."""
-    try:
-        # Verify category exists
-        cat = category_repo.get_category_by_id(body.category_id)
-        if not cat:
-            raise HTTPException(status_code=404, detail="Category not found.")
+    # Verify category exists
+    cat = category_repo.get_category_by_id(body.category_id)
+    if not cat:
+        raise HTTPException(status_code=404, detail="Category not found.")
 
-        # Get transaction text fields for keyword learning
-        description, creditor_name, debtor_name = _get_transaction_text_fields(
-            transaction_repo, account_id, transaction_id
-        )
+    # Get transaction text fields for keyword learning
+    description, creditor_name, debtor_name = _get_transaction_text_fields(
+        transaction_repo, account_id, transaction_id
+    )
 
-        category_repo.assign_category(
-            account_id=account_id,
-            transaction_id=transaction_id,
-            category_id=body.category_id,
-            description=description,
-            creditor_name=creditor_name,
-            debtor_name=debtor_name,
-        )
-        return {"status": "ok"}
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Failed to assign category: {e}")
-        raise HTTPException(status_code=500, detail="Failed to assign category.") from e
+    category_repo.assign_category(
+        account_id=account_id,
+        transaction_id=transaction_id,
+        category_id=body.category_id,
+        description=description,
+        creditor_name=creditor_name,
+        debtor_name=debtor_name,
+    )
+    return {"status": "ok"}
 
 
 @router.delete("/transactions/{account_id}/{transaction_id}/category")
@@ -206,27 +169,21 @@ async def remove_transaction_category(
     transaction_repo: Annotated[TransactionRepository, Depends()],
 ) -> dict[str, str]:
     """Remove category from a transaction."""
-    try:
-        # Get transaction text fields for keyword unlearning
-        description, creditor_name, debtor_name = _get_transaction_text_fields(
-            transaction_repo, account_id, transaction_id
-        )
+    # Get transaction text fields for keyword unlearning
+    description, creditor_name, debtor_name = _get_transaction_text_fields(
+        transaction_repo, account_id, transaction_id
+    )
 
-        removed = category_repo.remove_category(
-            account_id=account_id,
-            transaction_id=transaction_id,
-            description=description,
-            creditor_name=creditor_name,
-            debtor_name=debtor_name,
-        )
-        if not removed:
-            raise HTTPException(status_code=404, detail="No category assignment found.")
-        return {"status": "ok"}
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Failed to remove category: {e}")
-        raise HTTPException(status_code=500, detail="Failed to remove category.") from e
+    removed = category_repo.remove_category(
+        account_id=account_id,
+        transaction_id=transaction_id,
+        description=description,
+        creditor_name=creditor_name,
+        debtor_name=debtor_name,
+    )
+    if not removed:
+        raise HTTPException(status_code=404, detail="No category assignment found.")
+    return {"status": "ok"}
 
 
 @router.get(
@@ -240,27 +197,21 @@ async def suggest_transaction_category(
     transaction_repo: Annotated[TransactionRepository, Depends()],
 ) -> list[CategorySuggestion]:
     """Get category suggestions for a transaction."""
-    try:
-        # Get transaction text fields
-        description, creditor_name, debtor_name = _get_transaction_text_fields(
-            transaction_repo, account_id, transaction_id
-        )
+    # Get transaction text fields
+    description, creditor_name, debtor_name = _get_transaction_text_fields(
+        transaction_repo, account_id, transaction_id
+    )
 
-        suggestions = category_repo.suggest_category(
-            description=description,
-            creditor_name=creditor_name,
-            debtor_name=debtor_name,
+    suggestions = category_repo.suggest_category(
+        description=description,
+        creditor_name=creditor_name,
+        debtor_name=debtor_name,
+    )
+    return [
+        CategorySuggestion(
+            category=Category(**s["category"]),
+            score=s["score"],
+            confidence=s["confidence"],
         )
-        return [
-            CategorySuggestion(
-                category=Category(**s["category"]),
-                score=s["score"],
-                confidence=s["confidence"],
-            )
-            for s in suggestions
-        ]
-    except Exception as e:
-        logger.error(f"Failed to get category suggestions: {e}")
-        raise HTTPException(
-            status_code=500, detail="Failed to get category suggestions."
-        ) from e
+        for s in suggestions
+    ]

--- a/leggen/api/routes/notifications.py
+++ b/leggen/api/routes/notifications.py
@@ -131,18 +131,20 @@ async def get_notification_services() -> dict[str, NotificationServiceStatus]:
     notifications_config = config.notifications_config
     discord = notifications_config.get("discord", {})
     telegram = notifications_config.get("telegram", {})
+    discord_configured = bool(discord.get("webhook"))
+    telegram_configured = bool(telegram.get("token") and telegram.get("chat_id"))
 
     return {
         "discord": NotificationServiceStatus(
             name="Discord",
-            enabled=bool(discord.get("webhook")),
-            configured=bool(discord.get("webhook")),
+            enabled=discord_configured,
+            configured=discord_configured,
             active=discord.get("enabled", True),
         ),
         "telegram": NotificationServiceStatus(
             name="Telegram",
-            enabled=bool(telegram.get("token") and telegram.get("chat_id")),
-            configured=bool(telegram.get("token") and telegram.get("chat_id")),
+            enabled=telegram_configured,
+            configured=telegram_configured,
             active=telegram.get("enabled", True),
         ),
     }

--- a/leggen/api/routes/notifications.py
+++ b/leggen/api/routes/notifications.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, HTTPException
 from leggen.api.models.notifications import (
     DiscordConfig,
     NotificationFilters,
+    NotificationServiceStatus,
     NotificationSettings,
     NotificationTest,
     TelegramConfig,
@@ -125,29 +126,25 @@ async def test_notification(test_request: NotificationTest) -> dict:
 
 
 @router.get("/notifications/services")
-async def get_notification_services() -> dict:
+async def get_notification_services() -> dict[str, NotificationServiceStatus]:
     """Get available notification services and their status"""
     notifications_config = config.notifications_config
+    discord = notifications_config.get("discord", {})
+    telegram = notifications_config.get("telegram", {})
 
     return {
-        "discord": {
-            "name": "Discord",
-            "enabled": bool(notifications_config.get("discord", {}).get("webhook")),
-            "configured": bool(notifications_config.get("discord", {}).get("webhook")),
-            "active": notifications_config.get("discord", {}).get("enabled", True),
-        },
-        "telegram": {
-            "name": "Telegram",
-            "enabled": bool(
-                notifications_config.get("telegram", {}).get("token")
-                and notifications_config.get("telegram", {}).get("chat_id")
-            ),
-            "configured": bool(
-                notifications_config.get("telegram", {}).get("token")
-                and notifications_config.get("telegram", {}).get("chat_id")
-            ),
-            "active": notifications_config.get("telegram", {}).get("enabled", True),
-        },
+        "discord": NotificationServiceStatus(
+            name="Discord",
+            enabled=bool(discord.get("webhook")),
+            configured=bool(discord.get("webhook")),
+            active=discord.get("enabled", True),
+        ),
+        "telegram": NotificationServiceStatus(
+            name="Telegram",
+            enabled=bool(telegram.get("token") and telegram.get("chat_id")),
+            configured=bool(telegram.get("token") and telegram.get("chat_id")),
+            active=telegram.get("enabled", True),
+        ),
     }
 
 

--- a/leggen/api/routes/notifications.py
+++ b/leggen/api/routes/notifications.py
@@ -1,7 +1,6 @@
 from typing import Any, Dict
 
 from fastapi import APIRouter, HTTPException
-from loguru import logger
 
 from leggen.api.models.notifications import (
     DiscordConfig,
@@ -20,41 +19,32 @@ router = APIRouter()
 @router.get("/notifications/settings")
 async def get_notification_settings() -> NotificationSettings:
     """Get current notification settings"""
-    try:
-        notifications_config = config.notifications_config
-        filters_config = config.filters_config
+    notifications_config = config.notifications_config
+    filters_config = config.filters_config
 
-        # Build response safely without exposing secrets
-        discord_config = notifications_config.get("discord", {})
-        telegram_config = notifications_config.get("telegram", {})
+    # Build response safely without exposing secrets
+    discord_config = notifications_config.get("discord", {})
+    telegram_config = notifications_config.get("telegram", {})
 
-        settings = NotificationSettings(
-            discord=DiscordConfig(
-                webhook=mask_secret(discord_config.get("webhook")),
-                enabled=discord_config.get("enabled", True),
-            )
-            if discord_config.get("webhook")
-            else None,
-            telegram=TelegramConfig(
-                token=mask_secret(telegram_config.get("token")),
-                chat_id=telegram_config.get("chat_id", 0),
-                enabled=telegram_config.get("enabled", True),
-            )
-            if telegram_config.get("token")
-            else None,
-            filters=NotificationFilters(
-                case_insensitive=filters_config.get("case_insensitive", []),
-                case_sensitive=filters_config.get("case_sensitive"),
-            ),
+    return NotificationSettings(
+        discord=DiscordConfig(
+            webhook=mask_secret(discord_config.get("webhook")),
+            enabled=discord_config.get("enabled", True),
         )
-
-        return settings
-
-    except Exception as e:
-        logger.error(f"Failed to get notification settings: {e}")
-        raise HTTPException(
-            status_code=500, detail="Failed to get notification settings."
-        ) from e
+        if discord_config.get("webhook")
+        else None,
+        telegram=TelegramConfig(
+            token=mask_secret(telegram_config.get("token")),
+            chat_id=telegram_config.get("chat_id", 0),
+            enabled=telegram_config.get("enabled", True),
+        )
+        if telegram_config.get("token")
+        else None,
+        filters=NotificationFilters(
+            case_insensitive=filters_config.get("case_insensitive", []),
+            case_sensitive=filters_config.get("case_sensitive"),
+        ),
+    )
 
 
 @router.put("/notifications/settings")
@@ -66,130 +56,99 @@ async def update_notification_settings(settings: NotificationSettings) -> dict:
     from wiping the settings it does not mention. An explicit `null` service
     removes it, and an explicit empty filter list clears it.
     """
-    try:
-        # Clients echo back masked secrets from GET to mean "keep current value"
-        stored_config = config.notifications_config
-        notifications_config = dict(stored_config)
+    # Clients echo back masked secrets from GET to mean "keep current value"
+    stored_config = config.notifications_config
+    notifications_config = dict(stored_config)
 
-        if "discord" in settings.model_fields_set:
-            if settings.discord is None:
-                notifications_config.pop("discord", None)
-            else:
-                try:
-                    webhook = resolve_secret(
-                        settings.discord.webhook,
-                        stored_config.get("discord", {}).get("webhook"),
-                        "Discord webhook",
-                    )
-                except MaskedSecretError as e:
-                    raise HTTPException(status_code=400, detail=str(e)) from e
-                notifications_config["discord"] = {
-                    "webhook": webhook,
-                    "enabled": settings.discord.enabled,
-                }
+    if "discord" in settings.model_fields_set:
+        if settings.discord is None:
+            notifications_config.pop("discord", None)
+        else:
+            try:
+                webhook = resolve_secret(
+                    settings.discord.webhook,
+                    stored_config.get("discord", {}).get("webhook"),
+                    "Discord webhook",
+                )
+            except MaskedSecretError as e:
+                raise HTTPException(status_code=400, detail=str(e)) from e
+            notifications_config["discord"] = {
+                "webhook": webhook,
+                "enabled": settings.discord.enabled,
+            }
 
-        if "telegram" in settings.model_fields_set:
-            if settings.telegram is None:
-                notifications_config.pop("telegram", None)
-            else:
-                try:
-                    token = resolve_secret(
-                        settings.telegram.token,
-                        stored_config.get("telegram", {}).get("token"),
-                        "Telegram token",
-                    )
-                except MaskedSecretError as e:
-                    raise HTTPException(status_code=400, detail=str(e)) from e
-                notifications_config["telegram"] = {
-                    "token": token,
-                    "chat_id": settings.telegram.chat_id,
-                    "enabled": settings.telegram.enabled,
-                }
+    if "telegram" in settings.model_fields_set:
+        if settings.telegram is None:
+            notifications_config.pop("telegram", None)
+        else:
+            try:
+                token = resolve_secret(
+                    settings.telegram.token,
+                    stored_config.get("telegram", {}).get("token"),
+                    "Telegram token",
+                )
+            except MaskedSecretError as e:
+                raise HTTPException(status_code=400, detail=str(e)) from e
+            notifications_config["telegram"] = {
+                "token": token,
+                "chat_id": settings.telegram.chat_id,
+                "enabled": settings.telegram.enabled,
+            }
 
-        if notifications_config != stored_config:
-            config.update_section("notifications", notifications_config)
+    if notifications_config != stored_config:
+        config.update_section("notifications", notifications_config)
 
-        # `exclude_none` on save would drop a null list, so cleared filters are
-        # written as empty lists rather than None.
-        if settings.filters is not None:
-            filters_config: Dict[str, Any] = dict(config.filters_config)
-            for field in ("case_insensitive", "case_sensitive"):
-                if field in settings.filters.model_fields_set:
-                    filters_config[field] = getattr(settings.filters, field) or []
-            config.update_section("filters", filters_config)
+    # `exclude_none` on save would drop a null list, so cleared filters are
+    # written as empty lists rather than None.
+    if settings.filters is not None:
+        filters_config: Dict[str, Any] = dict(config.filters_config)
+        for field in ("case_insensitive", "case_sensitive"):
+            if field in settings.filters.model_fields_set:
+                filters_config[field] = getattr(settings.filters, field) or []
+        config.update_section("filters", filters_config)
 
-        return {"updated": True}
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Failed to update notification settings: {e}")
-        raise HTTPException(
-            status_code=500, detail="Failed to update notification settings."
-        ) from e
+    return {"updated": True}
 
 
 @router.post("/notifications/test")
 async def test_notification(test_request: NotificationTest) -> dict:
     """Send a test notification"""
-    try:
-        success = await NotificationService().send_test_notification(
-            test_request.service
+    success = await NotificationService().send_test_notification(test_request.service)
+
+    if not success:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Failed to send test notification to {test_request.service}",
         )
 
-        if not success:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Failed to send test notification to {test_request.service}",
-            )
-
-        return {"sent": True}
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Failed to send test notification: {e}")
-        raise HTTPException(
-            status_code=500, detail="Failed to send test notification."
-        ) from e
+    return {"sent": True}
 
 
 @router.get("/notifications/services")
 async def get_notification_services() -> dict:
     """Get available notification services and their status"""
-    try:
-        notifications_config = config.notifications_config
+    notifications_config = config.notifications_config
 
-        services = {
-            "discord": {
-                "name": "Discord",
-                "enabled": bool(notifications_config.get("discord", {}).get("webhook")),
-                "configured": bool(
-                    notifications_config.get("discord", {}).get("webhook")
-                ),
-                "active": notifications_config.get("discord", {}).get("enabled", True),
-            },
-            "telegram": {
-                "name": "Telegram",
-                "enabled": bool(
-                    notifications_config.get("telegram", {}).get("token")
-                    and notifications_config.get("telegram", {}).get("chat_id")
-                ),
-                "configured": bool(
-                    notifications_config.get("telegram", {}).get("token")
-                    and notifications_config.get("telegram", {}).get("chat_id")
-                ),
-                "active": notifications_config.get("telegram", {}).get("enabled", True),
-            },
-        }
-
-        return services
-
-    except Exception as e:
-        logger.error(f"Failed to get notification services: {e}")
-        raise HTTPException(
-            status_code=500, detail="Failed to get notification services."
-        ) from e
+    return {
+        "discord": {
+            "name": "Discord",
+            "enabled": bool(notifications_config.get("discord", {}).get("webhook")),
+            "configured": bool(notifications_config.get("discord", {}).get("webhook")),
+            "active": notifications_config.get("discord", {}).get("enabled", True),
+        },
+        "telegram": {
+            "name": "Telegram",
+            "enabled": bool(
+                notifications_config.get("telegram", {}).get("token")
+                and notifications_config.get("telegram", {}).get("chat_id")
+            ),
+            "configured": bool(
+                notifications_config.get("telegram", {}).get("token")
+                and notifications_config.get("telegram", {}).get("chat_id")
+            ),
+            "active": notifications_config.get("telegram", {}).get("enabled", True),
+        },
+    }
 
 
 # Declared before the /{service} route below, which would otherwise match
@@ -197,38 +156,22 @@ async def get_notification_services() -> dict:
 @router.delete("/notifications/settings/filters")
 async def delete_notification_filters() -> dict:
     """Remove all notification filters"""
-    try:
-        config.update_section("filters", {})
+    config.update_section("filters", {})
 
-        return {"deleted": "filters"}
-
-    except Exception as e:
-        logger.error(f"Failed to delete notification filters: {e}")
-        raise HTTPException(
-            status_code=500, detail="Failed to delete notification filters."
-        ) from e
+    return {"deleted": "filters"}
 
 
 @router.delete("/notifications/settings/{service}")
 async def delete_notification_service(service: str) -> dict:
     """Delete/disable a notification service"""
-    try:
-        if service not in ["discord", "telegram"]:
-            raise HTTPException(
-                status_code=400, detail="Service must be 'discord' or 'telegram'"
-            )
-
-        notifications_config = config.notifications_config.copy()
-        if service in notifications_config:
-            del notifications_config[service]
-            config.update_section("notifications", notifications_config)
-
-        return {"deleted": service}
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Failed to delete notification service {service}: {e}")
+    if service not in ["discord", "telegram"]:
         raise HTTPException(
-            status_code=500, detail="Failed to delete notification service."
-        ) from e
+            status_code=400, detail="Service must be 'discord' or 'telegram'"
+        )
+
+    notifications_config = config.notifications_config.copy()
+    if service in notifications_config:
+        del notifications_config[service]
+        config.update_section("notifications", notifications_config)
+
+    return {"deleted": service}

--- a/leggen/api/routes/sync.py
+++ b/leggen/api/routes/sync.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 
 from leggen.api.models.common import PaginatedResponse
 from leggen.api.models.sync import (
+    SyncOperation,
     SyncRequest,
     SyncResult,
     SyncScheduleRequest,
@@ -93,7 +94,7 @@ async def update_sync_schedule(request: SyncScheduleRequest) -> SyncScheduleResp
 async def get_sync_operations(
     page: int = Query(default=1, ge=1, description="Page number (1-based)"),
     per_page: int = Query(default=50, ge=1, le=500, description="Items per page"),
-) -> PaginatedResponse[dict]:
+) -> PaginatedResponse[SyncOperation]:
     """Get sync operations history"""
     sync_repo = SyncRepository()
     operations = sync_repo.get_operations(limit=per_page, offset=(page - 1) * per_page)
@@ -101,7 +102,7 @@ async def get_sync_operations(
     total_pages = (total + per_page - 1) // per_page
 
     return PaginatedResponse(
-        data=operations,
+        data=[SyncOperation(**operation) for operation in operations],
         total=total,
         page=page,
         per_page=per_page,

--- a/leggen/api/routes/sync.py
+++ b/leggen/api/routes/sync.py
@@ -12,7 +12,6 @@ from leggen.api.models.sync import (
 )
 from leggen.background.scheduler import scheduler
 from leggen.repositories import AccountRepository, SyncRepository
-from leggen.services.sync_service import SyncAlreadyRunningError
 from leggen.utils.config import config
 
 router = APIRouter()
@@ -38,12 +37,11 @@ async def trigger_sync(
                 detail=f"Unknown account IDs: {', '.join(unknown_ids)}",
             )
 
-    try:
-        return await scheduler.sync_service.sync_all_accounts(
-            full_sync, "api", account_ids=account_ids or None
-        )
-    except SyncAlreadyRunningError as e:
-        raise HTTPException(status_code=409, detail="Sync is already running.") from e
+    # SyncAlreadyRunningError is a ConflictError; the global handler
+    # renders it as a 409 with its own code.
+    return await scheduler.sync_service.sync_all_accounts(
+        full_sync, "api", account_ids=account_ids or None
+    )
 
 
 @router.get("/sync/schedule")

--- a/leggen/api/routes/sync.py
+++ b/leggen/api/routes/sync.py
@@ -1,7 +1,6 @@
 from typing import Annotated, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from loguru import logger
 
 from leggen.api.models.common import PaginatedResponse
 from leggen.api.models.sync import (
@@ -24,90 +23,70 @@ async def trigger_sync(
     sync_request: Optional[SyncRequest] = None,
 ) -> SyncResult:
     """Run sync synchronously and return results"""
+    full_sync = sync_request.full_sync if sync_request else False
+    account_ids = sync_request.account_ids if sync_request else None
+
+    if account_ids:
+        known_ids = {
+            a["id"] for a in account_repo.get_accounts(account_ids=account_ids)
+        }
+        unknown_ids = sorted(set(account_ids) - known_ids)
+        if unknown_ids:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Unknown account IDs: {', '.join(unknown_ids)}",
+            )
+
     try:
-        full_sync = sync_request.full_sync if sync_request else False
-        account_ids = sync_request.account_ids if sync_request else None
-
-        if account_ids:
-            known_ids = {
-                a["id"] for a in account_repo.get_accounts(account_ids=account_ids)
-            }
-            unknown_ids = sorted(set(account_ids) - known_ids)
-            if unknown_ids:
-                raise HTTPException(
-                    status_code=404,
-                    detail=f"Unknown account IDs: {', '.join(unknown_ids)}",
-                )
-
-        result = await scheduler.sync_service.sync_all_accounts(
+        return await scheduler.sync_service.sync_all_accounts(
             full_sync, "api", account_ids=account_ids or None
         )
-
-        return result
-
-    except HTTPException:
-        raise
     except SyncAlreadyRunningError as e:
         raise HTTPException(status_code=409, detail="Sync is already running.") from e
-    except Exception as e:
-        logger.error(f"Failed to run sync: {e}")
-        raise HTTPException(status_code=500, detail="Failed to run sync.") from e
 
 
 @router.get("/sync/schedule")
 async def get_sync_schedule() -> SyncScheduleResponse:
     """Get current sync schedule configuration"""
-    try:
-        schedule_config = config.scheduler_config.get("sync", {})
-        next_sync = scheduler.get_next_sync_time()
+    schedule_config = config.scheduler_config.get("sync", {})
+    next_sync = scheduler.get_next_sync_time()
 
-        return SyncScheduleResponse(
-            enabled=schedule_config.get("enabled", True),
-            hour=schedule_config.get("hour", 3),
-            minute=schedule_config.get("minute", 0),
-            cron=schedule_config.get("cron"),
-            next_sync_time=next_sync.isoformat() if next_sync else None,
-        )
-    except Exception as e:
-        logger.error(f"Failed to get sync schedule: {e}")
-        raise HTTPException(
-            status_code=500, detail="Failed to get sync schedule."
-        ) from e
+    return SyncScheduleResponse(
+        enabled=schedule_config.get("enabled", True),
+        hour=schedule_config.get("hour", 3),
+        minute=schedule_config.get("minute", 0),
+        cron=schedule_config.get("cron"),
+        next_sync_time=next_sync.isoformat() if next_sync else None,
+    )
 
 
 @router.put("/sync/schedule")
 async def update_sync_schedule(request: SyncScheduleRequest) -> SyncScheduleResponse:
     """Update sync schedule configuration"""
-    try:
-        sync_config: dict[str, object] = {
-            "enabled": request.enabled,
-            "hour": request.hour,
-            "minute": request.minute,
-        }
-        if request.cron:
-            sync_config["cron"] = request.cron
+    sync_config: dict[str, object] = {
+        "enabled": request.enabled,
+        "hour": request.hour,
+        "minute": request.minute,
+    }
+    if request.cron:
+        sync_config["cron"] = request.cron
 
-        # Merge into the existing section: replacing it wholesale would reset
-        # the backup schedule to defaults.
-        scheduler_section = dict(config.scheduler_config)
-        scheduler_section["sync"] = sync_config
-        config.update_section("scheduler", scheduler_section)
-        scheduler.reschedule_sync(sync_config)
+    # Merge into the existing section: replacing it wholesale would reset
+    # the backup schedule to defaults.
+    scheduler_section = dict(config.scheduler_config)
+    scheduler_section["sync"] = sync_config
+    config.update_section("scheduler", scheduler_section)
+    scheduler.reschedule_sync(sync_config)
 
-        next_sync = scheduler.get_next_sync_time()
+    next_sync = scheduler.get_next_sync_time()
 
-        return SyncScheduleResponse(
-            enabled=request.enabled,
-            hour=request.hour,
-            minute=request.minute,
-            cron=request.cron,
-            next_sync_time=next_sync.isoformat() if next_sync else None,
-        )
-    except Exception as e:
-        logger.error(f"Failed to update sync schedule: {e}")
-        raise HTTPException(
-            status_code=500, detail="Failed to update sync schedule."
-        ) from e
+    return SyncScheduleResponse(
+        enabled=request.enabled,
+        hour=request.hour,
+        minute=request.minute,
+        cron=request.cron,
+        next_sync_time=next_sync.isoformat() if next_sync else None,
+    )
 
 
 @router.get("/sync/operations")
@@ -116,26 +95,17 @@ async def get_sync_operations(
     per_page: int = Query(default=50, ge=1, le=500, description="Items per page"),
 ) -> PaginatedResponse[dict]:
     """Get sync operations history"""
-    try:
-        sync_repo = SyncRepository()
-        operations = sync_repo.get_operations(
-            limit=per_page, offset=(page - 1) * per_page
-        )
-        total = sync_repo.get_operations_count()
-        total_pages = (total + per_page - 1) // per_page
+    sync_repo = SyncRepository()
+    operations = sync_repo.get_operations(limit=per_page, offset=(page - 1) * per_page)
+    total = sync_repo.get_operations_count()
+    total_pages = (total + per_page - 1) // per_page
 
-        return PaginatedResponse(
-            data=operations,
-            total=total,
-            page=page,
-            per_page=per_page,
-            total_pages=total_pages,
-            has_next=page < total_pages,
-            has_prev=page > 1,
-        )
-
-    except Exception as e:
-        logger.error(f"Failed to get sync operations: {e}")
-        raise HTTPException(
-            status_code=500, detail="Failed to get sync operations."
-        ) from e
+    return PaginatedResponse(
+        data=operations,
+        total=total,
+        page=page,
+        per_page=per_page,
+        total_pages=total_pages,
+        has_next=page < total_pages,
+        has_prev=page > 1,
+    )

--- a/leggen/api/routes/transactions.py
+++ b/leggen/api/routes/transactions.py
@@ -1,16 +1,16 @@
-from collections import Counter
 from typing import Annotated, List, Literal, Optional, Union
 
-from fastapi import APIRouter, Depends, HTTPException, Query
-from loguru import logger
+from fastapi import APIRouter, Depends, Query
 
 from leggen.api.models.accounts import Transaction, TransactionSummary
 from leggen.api.models.common import PaginatedResponse
+from leggen.api.models.stats import CategoryStats, MonthlyStats, TransactionStats
 from leggen.repositories import TransactionRepository
 from leggen.services.data_processors import (
     calculate_category_stats,
     calculate_monthly_stats,
 )
+from leggen.utils.paths import path_manager
 
 router = APIRouter()
 
@@ -52,92 +52,85 @@ async def get_all_transactions(
     ),
 ) -> PaginatedResponse[Union[TransactionSummary, Transaction]]:
     """Get all transactions from database with filtering options"""
-    try:
-        # Calculate offset from page and per_page
-        offset = (page - 1) * per_page
-        limit = per_page
+    # Calculate offset from page and per_page
+    offset = (page - 1) * per_page
+    limit = per_page
 
-        # Get transactions from database
-        db_transactions = transaction_repo.get_transactions(
-            account_id=account_id,
-            limit=limit,
-            offset=offset,
-            date_from=date_from,
-            date_to=date_to,
-            min_amount=min_amount,
-            max_amount=max_amount,
-            search=search,
-            category_id=category_id,
-        )
+    # Get transactions from database
+    db_transactions = transaction_repo.get_transactions(
+        account_id=account_id,
+        limit=limit,
+        offset=offset,
+        date_from=date_from,
+        date_to=date_to,
+        min_amount=min_amount,
+        max_amount=max_amount,
+        search=search,
+        category_id=category_id,
+    )
 
-        # Get total count for pagination info (respecting the same filters)
-        total_transactions = transaction_repo.get_count(
-            account_id=account_id,
-            date_from=date_from,
-            date_to=date_to,
-            min_amount=min_amount,
-            max_amount=max_amount,
-            search=search,
-            category_id=category_id,
-        )
+    # Get total count for pagination info (respecting the same filters)
+    total_transactions = transaction_repo.get_count(
+        account_id=account_id,
+        date_from=date_from,
+        date_to=date_to,
+        min_amount=min_amount,
+        max_amount=max_amount,
+        search=search,
+        category_id=category_id,
+    )
 
-        if summary_only:
-            # Return simplified transaction summaries
-            data: list[TransactionSummary | Transaction] = [
-                TransactionSummary(
-                    transaction_id=txn["transactionId"],  # NEW: stable bank-provided ID
-                    internal_transaction_id=txn.get("internalTransactionId"),
-                    date=txn["transactionDate"],
-                    description=txn["description"],
-                    amount=txn["transactionValue"],
-                    currency=txn["transactionCurrency"],
-                    status=txn["transactionStatus"],
-                    account_id=txn["accountId"],
-                    category_id=txn.get("categoryId"),
-                    category_name=txn.get("categoryName"),
-                    category_color=txn.get("categoryColor"),
-                )
-                for txn in db_transactions
-            ]
-        else:
-            # Return full transaction details
-            data = [
-                Transaction(
-                    transaction_id=txn["transactionId"],  # NEW: stable bank-provided ID
-                    internal_transaction_id=txn.get("internalTransactionId"),
-                    institution_id=txn["institutionId"],
-                    iban=txn["iban"],
-                    account_id=txn["accountId"],
-                    transaction_date=txn["transactionDate"],
-                    description=txn["description"],
-                    transaction_value=txn["transactionValue"],
-                    transaction_currency=txn["transactionCurrency"],
-                    transaction_status=txn["transactionStatus"],
-                    raw_transaction=txn["rawTransaction"],
-                    category_id=txn.get("categoryId"),
-                    category_name=txn.get("categoryName"),
-                    category_color=txn.get("categoryColor"),
-                )
-                for txn in db_transactions
-            ]
+    if summary_only:
+        # Return simplified transaction summaries
+        data: list[TransactionSummary | Transaction] = [
+            TransactionSummary(
+                transaction_id=txn["transactionId"],  # NEW: stable bank-provided ID
+                internal_transaction_id=txn.get("internalTransactionId"),
+                date=txn["transactionDate"],
+                description=txn["description"],
+                amount=txn["transactionValue"],
+                currency=txn["transactionCurrency"],
+                status=txn["transactionStatus"],
+                account_id=txn["accountId"],
+                category_id=txn.get("categoryId"),
+                category_name=txn.get("categoryName"),
+                category_color=txn.get("categoryColor"),
+            )
+            for txn in db_transactions
+        ]
+    else:
+        # Return full transaction details
+        data = [
+            Transaction(
+                transaction_id=txn["transactionId"],  # NEW: stable bank-provided ID
+                internal_transaction_id=txn.get("internalTransactionId"),
+                institution_id=txn["institutionId"],
+                iban=txn["iban"],
+                account_id=txn["accountId"],
+                transaction_date=txn["transactionDate"],
+                description=txn["description"],
+                transaction_value=txn["transactionValue"],
+                transaction_currency=txn["transactionCurrency"],
+                transaction_status=txn["transactionStatus"],
+                raw_transaction=txn["rawTransaction"],
+                category_id=txn.get("categoryId"),
+                category_name=txn.get("categoryName"),
+                category_color=txn.get("categoryColor"),
+            )
+            for txn in db_transactions
+        ]
 
-        total_pages = (total_transactions + per_page - 1) // per_page
+    total_pages = (total_transactions + per_page - 1) // per_page
 
-        return PaginatedResponse(
-            data=data,
-            total=total_transactions,
-            page=page,
-            per_page=per_page,
-            total_pages=total_pages,
-            has_next=page < total_pages,
-            has_prev=page > 1,
-        )
-
-    except Exception as e:
-        logger.error(f"Failed to get transactions from database: {e}")
-        raise HTTPException(
-            status_code=500, detail="Failed to get transactions."
-        ) from e
+    return PaginatedResponse(
+        data=data,
+        total=total_transactions,
+        page=page,
+        per_page=per_page,
+        total_pages=total_pages,
+        has_next=page < total_pages,
+        has_prev=page > 1,
+    )
 
 
 @router.get("/transactions/stats")
@@ -163,116 +156,32 @@ async def get_transaction_stats(
         pattern=_CATEGORY_ID_PATTERN,
         description="Filter by category ID or 'uncategorized' for transactions without a category",
     ),
-) -> Union[dict, List[dict]]:
+) -> Union[TransactionStats, List[MonthlyStats]]:
     """Get transaction statistics for a date range.
 
     Without group_by: returns totals (transactions, income, expenses, etc.)
     With group_by=month: returns array of monthly stats.
     """
-    try:
-        if group_by == "month":
-            from leggen.utils.paths import path_manager
-
-            db_path = path_manager.get_database_path()
-            return calculate_monthly_stats(
-                db_path,
-                account_id=account_id,
-                date_from=date_from,
-                date_to=date_to,
-            )
-
-        # Default: return totals
-        recent_transactions = transaction_repo.get_transactions(
+    if group_by == "month":
+        db_path = path_manager.get_database_path()
+        monthly = calculate_monthly_stats(
+            db_path,
             account_id=account_id,
             date_from=date_from,
             date_to=date_to,
-            min_amount=min_amount,
-            max_amount=max_amount,
-            search=search,
-            category_id=category_id,
-            limit=None,
         )
+        return [MonthlyStats(**entry) for entry in monthly]
 
-        # Filter out transactions with categories that have exclude_from_stats=True
-        from leggen.repositories.category_repository import CategoryRepository
-
-        category_repo = CategoryRepository()
-        excluded_category_ids: set[int] = set()
-        for cat in category_repo.get_all_categories():
-            if cat.get("exclude_from_stats"):
-                excluded_category_ids.add(cat["id"])
-
-        if excluded_category_ids:
-            recent_transactions = [
-                txn
-                for txn in recent_transactions
-                if txn.get("categoryId") not in excluded_category_ids
-            ]
-
-        total_transactions = len(recent_transactions)
-
-        # Summing amounts across currencies is meaningless — compute money
-        # totals over the dominant currency only and report which one it is.
-        currency_counts = Counter(
-            txn.get("transactionCurrency") for txn in recent_transactions
-        )
-        currency = currency_counts.most_common(1)[0][0] if currency_counts else None
-        money_transactions = [
-            txn
-            for txn in recent_transactions
-            if txn.get("transactionCurrency") == currency
-        ]
-
-        total_income = sum(
-            txn["transactionValue"]
-            for txn in money_transactions
-            if txn["transactionValue"] > 0
-        )
-        total_expenses = sum(
-            abs(txn["transactionValue"])
-            for txn in money_transactions
-            if txn["transactionValue"] < 0
-        )
-        net_change = total_income - total_expenses
-
-        booked_count = len(
-            [txn for txn in recent_transactions if txn["transactionStatus"] == "booked"]
-        )
-        pending_count = len(
-            [
-                txn
-                for txn in recent_transactions
-                if txn["transactionStatus"] == "pending"
-            ]
-        )
-
-        unique_accounts = len({txn["accountId"] for txn in recent_transactions})
-
-        return {
-            "date_from": date_from,
-            "date_to": date_to,
-            "total_transactions": total_transactions,
-            "booked_transactions": booked_count,
-            "pending_transactions": pending_count,
-            "currency": currency,
-            "total_income": round(total_income, 2),
-            "total_expenses": round(total_expenses, 2),
-            "net_change": round(net_change, 2),
-            "average_transaction": round(
-                sum(txn["transactionValue"] for txn in money_transactions)
-                / len(money_transactions),
-                2,
-            )
-            if money_transactions
-            else 0,
-            "accounts_included": unique_accounts,
-        }
-
-    except Exception as e:
-        logger.error(f"Failed to get transaction stats from database: {e}")
-        raise HTTPException(
-            status_code=500, detail="Failed to get transaction stats."
-        ) from e
+    totals = transaction_repo.get_stats_totals(
+        account_id=account_id,
+        date_from=date_from,
+        date_to=date_to,
+        min_amount=min_amount,
+        max_amount=max_amount,
+        search=search,
+        category_id=category_id,
+    )
+    return TransactionStats(date_from=date_from, date_to=date_to, **totals)
 
 
 @router.get("/transactions/stats/by-category")
@@ -280,20 +189,13 @@ async def get_stats_by_category(
     date_from: str = Query(description="Start date (YYYY-MM-DD)"),
     date_to: str = Query(description="End date (YYYY-MM-DD)"),
     account_id: Optional[str] = Query(default=None, description="Filter by account ID"),
-) -> List[dict]:
+) -> List[CategoryStats]:
     """Get transaction statistics grouped by category."""
-    try:
-        from leggen.utils.paths import path_manager
-
-        db_path = path_manager.get_database_path()
-        return calculate_category_stats(
-            db_path,
-            account_id=account_id,
-            date_from=date_from,
-            date_to=date_to,
-        )
-    except Exception as e:
-        logger.error(f"Failed to get category stats: {e}")
-        raise HTTPException(
-            status_code=500, detail="Failed to get category stats."
-        ) from e
+    db_path = path_manager.get_database_path()
+    category_stats = calculate_category_stats(
+        db_path,
+        account_id=account_id,
+        date_from=date_from,
+        date_to=date_to,
+    )
+    return [CategoryStats(**entry) for entry in category_stats]

--- a/leggen/commands/server.py
+++ b/leggen/commands/server.py
@@ -10,6 +10,7 @@ from loguru import logger
 
 from leggen.api.dependencies.auth import get_current_user
 from leggen.api.errors import register_exception_handlers, use_error_schema_in_openapi
+from leggen.api.models.common import HealthStatus
 from leggen.api.routes import (
     accounts,
     auth,
@@ -152,11 +153,11 @@ def create_app() -> FastAPI:
         backup.router, prefix="/api/v1", tags=["backup"], dependencies=auth_deps
     )
 
-    @app.get("/api/v1/health")
+    @app.get("/api/v1/health", response_model=HealthStatus)
     async def health():
         """Health check endpoint for API connectivity"""
         try:
-            config_loaded = config._config is not None
+            config_loaded = config.is_loaded
 
             # Get version dynamically
             try:
@@ -164,11 +165,11 @@ def create_app() -> FastAPI:
             except metadata.PackageNotFoundError:
                 version = "dev"
 
-            return {
-                "status": "healthy",
-                "config_loaded": config_loaded,
-                "version": version,
-            }
+            return HealthStatus(
+                status="healthy",
+                config_loaded=config_loaded,
+                version=version,
+            )
         except Exception as e:
             # This endpoint is unauthenticated, so the failure reason stays in
             # the log; the status code is what callers act on.

--- a/leggen/repositories/balance_repository.py
+++ b/leggen/repositories/balance_repository.py
@@ -74,6 +74,22 @@ class BalanceRepository:
             logger.error(f"Failed to persist balances: {e}")
             raise
 
+    def get_latest_balances_by_account(self) -> Dict[str, List[Dict[str, Any]]]:
+        """Latest balances for every account in one query, grouped by account.
+
+        Rows with a NULL amount (possible on legacy data — the column is
+        nullable) are skipped: a balance without an amount is meaningless.
+        """
+        grouped: Dict[str, List[Dict[str, Any]]] = {}
+        for balance in self.get_balances():
+            if balance.get("amount") is None:
+                logger.warning(
+                    f"Skipping balance with NULL amount for {balance.get('account_id')}"
+                )
+                continue
+            grouped.setdefault(balance["account_id"], []).append(balance)
+        return grouped
+
     def get_balances(self, account_id: Optional[str] = None) -> List[Dict[str, Any]]:
         """Get latest balances from database"""
         if not db_exists():

--- a/leggen/repositories/transaction_repository.py
+++ b/leggen/repositories/transaction_repository.py
@@ -1,9 +1,18 @@
 import json
+import sqlite3
 from typing import Any, Dict, List, Optional, Union
 
 from loguru import logger
 
 from leggen.repositories.db import db_exists, get_db_connection
+
+# SQLite's default parameter limit is 999; keep IN() chunks safely under it.
+_SELECT_CHUNK_SIZE = 900
+
+# Shared JOIN fragment: category lookups hang off (accountId, transactionId).
+_CATEGORY_JOIN = """
+                LEFT JOIN transaction_categories tc ON t.accountId = tc.accountId AND t.transactionId = tc.transactionId
+                LEFT JOIN categories c ON tc.categoryId = c.id"""
 
 
 class TransactionRepository:
@@ -108,29 +117,40 @@ class TransactionRepository:
             with get_db_connection() as conn:
                 cursor = conn.cursor()
 
-                # One SELECT per account in the batch instead of one per
-                # transaction: load the existing rows into memory and compare
-                # there. A full-history sync is thousands of rows, not millions.
+                # Load only the batch's existing rows (chunked IN() to stay
+                # under SQLite's parameter limit) and compare in memory. An
+                # unconstrained per-account SELECT would read the whole
+                # history — including rawTransaction blobs — on every
+                # incremental sync.
                 existing_rows: Dict[tuple[str, str], tuple] = {}
-                for acct in {txn["accountId"] for txn in transactions}:
-                    cursor.execute(
-                        """SELECT
-                            accountId,
-                            transactionId,
-                            internalTransactionId,
-                            institutionId,
-                            iban,
-                            transactionDate,
-                            description,
-                            transactionValue,
-                            transactionCurrency,
-                            transactionStatus,
-                            rawTransaction
-                        FROM transactions WHERE accountId = ?""",
-                        (acct,),
+                by_account: Dict[str, List[str]] = {}
+                for txn in transactions:
+                    by_account.setdefault(txn["accountId"], []).append(
+                        txn["transactionId"]
                     )
-                    for row in cursor.fetchall():
-                        existing_rows[(row[0], row[1])] = tuple(row[2:])
+                for acct, txn_ids in by_account.items():
+                    for start in range(0, len(txn_ids), _SELECT_CHUNK_SIZE):
+                        chunk = txn_ids[start : start + _SELECT_CHUNK_SIZE]
+                        placeholders = ",".join("?" * len(chunk))
+                        cursor.execute(
+                            f"""SELECT
+                                accountId,
+                                transactionId,
+                                internalTransactionId,
+                                institutionId,
+                                iban,
+                                transactionDate,
+                                description,
+                                transactionValue,
+                                transactionCurrency,
+                                transactionStatus,
+                                rawTransaction
+                            FROM transactions
+                            WHERE accountId = ? AND transactionId IN ({placeholders})""",
+                            (acct, *chunk),
+                        )
+                        for row in cursor.fetchall():
+                            existing_rows[(row[0], row[1])] = tuple(row[2:])
 
                 new_transactions = []
                 updated_count = 0
@@ -159,24 +179,37 @@ class TransactionRepository:
                         new_transactions.append(transaction)
                     else:
                         updated_count += 1
+                    # Record the row so a duplicate key later in the same
+                    # batch is treated as an update, not a second insert.
+                    existing_rows[key] = row_values
+
+                insert_sql = """INSERT OR REPLACE INTO transactions (
+                    accountId,
+                    transactionId,
+                    internalTransactionId,
+                    institutionId,
+                    iban,
+                    transactionDate,
+                    description,
+                    transactionValue,
+                    transactionCurrency,
+                    transactionStatus,
+                    rawTransaction
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
 
                 if rows_to_write:
-                    cursor.executemany(
-                        """INSERT OR REPLACE INTO transactions (
-                            accountId,
-                            transactionId,
-                            internalTransactionId,
-                            institutionId,
-                            iban,
-                            transactionDate,
-                            description,
-                            transactionValue,
-                            transactionCurrency,
-                            transactionStatus,
-                            rawTransaction
-                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                        rows_to_write,
-                    )
+                    try:
+                        cursor.executemany(insert_sql, rows_to_write)
+                    except sqlite3.IntegrityError:
+                        # One bad row (e.g. a NULL key) must not sink the
+                        # whole batch: retry row by row and skip offenders.
+                        for row in rows_to_write:
+                            try:
+                                cursor.execute(insert_sql, row)
+                            except sqlite3.IntegrityError as e:
+                                logger.warning(
+                                    f"Failed to insert transaction {row[1]}: {e}"
+                                )
 
                 conn.commit()
 
@@ -219,10 +252,8 @@ class TransactionRepository:
             )
 
             query = (
-                """SELECT t.*, tc.categoryId, c.name as categoryName, c.color as categoryColor
-                FROM transactions t
-                LEFT JOIN transaction_categories tc ON t.accountId = tc.accountId AND t.transactionId = tc.transactionId
-                LEFT JOIN categories c ON tc.categoryId = c.id
+                f"""SELECT t.*, tc.categoryId, c.name as categoryName, c.color as categoryColor
+                FROM transactions t{_CATEGORY_JOIN}
                 WHERE 1=1"""
                 + filter_clause
             )
@@ -278,9 +309,7 @@ class TransactionRepository:
             )
 
             query = (
-                """SELECT COUNT(*) FROM transactions t
-                LEFT JOIN transaction_categories tc ON t.accountId = tc.accountId AND t.transactionId = tc.transactionId
-                LEFT JOIN categories c ON tc.categoryId = c.id
+                f"""SELECT COUNT(*) FROM transactions t{_CATEGORY_JOIN}
                 WHERE 1=1"""
                 + filter_clause
             )
@@ -332,9 +361,7 @@ class TransactionRepository:
             )
 
             base = (
-                """FROM transactions t
-                LEFT JOIN transaction_categories tc ON t.accountId = tc.accountId AND t.transactionId = tc.transactionId
-                LEFT JOIN categories c ON tc.categoryId = c.id
+                f"""FROM transactions t{_CATEGORY_JOIN}
                 WHERE (c.exclude_from_stats IS NULL OR c.exclude_from_stats = 0)"""
                 + filter_clause
             )
@@ -346,9 +373,11 @@ class TransactionRepository:
                 params,
             )
             row = cursor.fetchone()
-            currency = row["currency"] if row else None
-            if currency is None:
+            if row is None:
                 return empty
+            # A NULL currency (legacy rows) still counts as the dominant
+            # group, hence `IS ?` below instead of `= ?`.
+            currency = row["currency"]
 
             # Placeholder order matters: the four currency parameters sit in
             # the SELECT list, before the filter parameters from the WHERE.
@@ -358,10 +387,10 @@ class TransactionRepository:
                     SUM(CASE WHEN t.transactionStatus = 'booked' THEN 1 ELSE 0 END) AS booked_transactions,
                     SUM(CASE WHEN t.transactionStatus = 'pending' THEN 1 ELSE 0 END) AS pending_transactions,
                     COUNT(DISTINCT t.accountId) AS accounts_included,
-                    COALESCE(SUM(CASE WHEN t.transactionCurrency = ? AND t.transactionValue > 0 THEN t.transactionValue ELSE 0 END), 0) AS total_income,
-                    COALESCE(SUM(CASE WHEN t.transactionCurrency = ? AND t.transactionValue < 0 THEN ABS(t.transactionValue) ELSE 0 END), 0) AS total_expenses,
-                    COALESCE(SUM(CASE WHEN t.transactionCurrency = ? THEN t.transactionValue ELSE 0 END), 0) AS money_sum,
-                    SUM(CASE WHEN t.transactionCurrency = ? THEN 1 ELSE 0 END) AS money_count
+                    COALESCE(SUM(CASE WHEN t.transactionCurrency IS ? AND t.transactionValue > 0 THEN t.transactionValue ELSE 0 END), 0) AS total_income,
+                    COALESCE(SUM(CASE WHEN t.transactionCurrency IS ? AND t.transactionValue < 0 THEN ABS(t.transactionValue) ELSE 0 END), 0) AS total_expenses,
+                    COALESCE(SUM(CASE WHEN t.transactionCurrency IS ? THEN t.transactionValue ELSE 0 END), 0) AS money_sum,
+                    SUM(CASE WHEN t.transactionCurrency IS ? THEN 1 ELSE 0 END) AS money_count
                 {base}""",
                 [currency] * 4 + params,
             )

--- a/leggen/repositories/transaction_repository.py
+++ b/leggen/repositories/transaction_repository.py
@@ -290,6 +290,104 @@ class TransactionRepository:
             cursor.execute(query, params)
             return cursor.fetchone()[0]
 
+    def get_stats_totals(
+        self,
+        account_id: Optional[str] = None,
+        date_from: Optional[str] = None,
+        date_to: Optional[str] = None,
+        min_amount: Optional[float] = None,
+        max_amount: Optional[float] = None,
+        search: Optional[str] = None,
+        category_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Aggregate totals for the filtered set, computed in SQL.
+
+        Transactions whose category is flagged exclude_from_stats are left
+        out. Summing amounts across currencies is meaningless, so money
+        totals cover only the dominant (most frequent) currency of the set,
+        while the counts cover every matching transaction.
+        """
+        empty: Dict[str, Any] = {
+            "total_transactions": 0,
+            "booked_transactions": 0,
+            "pending_transactions": 0,
+            "currency": None,
+            "total_income": 0,
+            "total_expenses": 0,
+            "net_change": 0,
+            "average_transaction": 0,
+            "accounts_included": 0,
+        }
+        if not db_exists():
+            return empty
+
+        with get_db_connection(row_factory=True) as conn:
+            cursor = conn.cursor()
+
+            filter_clause, params = self._build_filter_clause(
+                account_id=account_id,
+                date_from=date_from,
+                date_to=date_to,
+                min_amount=min_amount,
+                max_amount=max_amount,
+                search=search,
+                category_id=category_id,
+            )
+
+            base = (
+                """FROM transactions t
+                LEFT JOIN transaction_categories tc ON t.accountId = tc.accountId AND t.transactionId = tc.transactionId
+                LEFT JOIN categories c ON tc.categoryId = c.id
+                WHERE (c.exclude_from_stats IS NULL OR c.exclude_from_stats = 0)"""
+                + filter_clause
+            )
+
+            cursor.execute(
+                f"""SELECT t.transactionCurrency AS currency, COUNT(*) AS n
+                {base}
+                GROUP BY t.transactionCurrency ORDER BY n DESC LIMIT 1""",
+                params,
+            )
+            row = cursor.fetchone()
+            currency = row["currency"] if row else None
+            if currency is None:
+                return empty
+
+            # Placeholder order matters: the four currency parameters sit in
+            # the SELECT list, before the filter parameters from the WHERE.
+            cursor.execute(
+                f"""SELECT
+                    COUNT(*) AS total_transactions,
+                    SUM(CASE WHEN t.transactionStatus = 'booked' THEN 1 ELSE 0 END) AS booked_transactions,
+                    SUM(CASE WHEN t.transactionStatus = 'pending' THEN 1 ELSE 0 END) AS pending_transactions,
+                    COUNT(DISTINCT t.accountId) AS accounts_included,
+                    COALESCE(SUM(CASE WHEN t.transactionCurrency = ? AND t.transactionValue > 0 THEN t.transactionValue ELSE 0 END), 0) AS total_income,
+                    COALESCE(SUM(CASE WHEN t.transactionCurrency = ? AND t.transactionValue < 0 THEN ABS(t.transactionValue) ELSE 0 END), 0) AS total_expenses,
+                    COALESCE(SUM(CASE WHEN t.transactionCurrency = ? THEN t.transactionValue ELSE 0 END), 0) AS money_sum,
+                    SUM(CASE WHEN t.transactionCurrency = ? THEN 1 ELSE 0 END) AS money_count
+                {base}""",
+                [currency] * 4 + params,
+            )
+            totals = cursor.fetchone()
+
+            money_count = totals["money_count"] or 0
+            total_income = round(totals["total_income"], 2)
+            total_expenses = round(totals["total_expenses"], 2)
+
+            return {
+                "total_transactions": totals["total_transactions"],
+                "booked_transactions": totals["booked_transactions"] or 0,
+                "pending_transactions": totals["pending_transactions"] or 0,
+                "currency": currency,
+                "total_income": total_income,
+                "total_expenses": total_expenses,
+                "net_change": round(total_income - total_expenses, 2),
+                "average_transaction": round(totals["money_sum"] / money_count, 2)
+                if money_count
+                else 0,
+                "accounts_included": totals["accounts_included"],
+            }
+
     def get_transaction_by_id(
         self, account_id: str, transaction_id: str
     ) -> Optional[Dict[str, Any]]:

--- a/leggen/repositories/transaction_repository.py
+++ b/leggen/repositories/transaction_repository.py
@@ -113,44 +113,51 @@ class TransactionRepository:
         Returns (new_transactions, updated_count). Rows that already exist
         with identical content are left untouched and counted in neither.
         """
+        # Every row must belong to the account being persisted — a mismatch
+        # would write under another account's primary key while this method
+        # logs success for account_id.
+        mismatched = {txn["accountId"] for txn in transactions} - {account_id}
+        if mismatched:
+            raise ValueError(
+                f"persist() called for account {account_id} with transactions "
+                f"belonging to {sorted(mismatched)}"
+            )
+
         try:
             with get_db_connection() as conn:
                 cursor = conn.cursor()
 
-                # Load only the batch's existing rows (chunked IN() to stay
-                # under SQLite's parameter limit) and compare in memory. An
-                # unconstrained per-account SELECT would read the whole
-                # history — including rawTransaction blobs — on every
+                # Load only the batch's existing rows (chunked, deduplicated
+                # IN() to stay under SQLite's parameter limit) and compare in
+                # memory. An unconstrained account SELECT would read the
+                # whole history — including rawTransaction blobs — on every
                 # incremental sync.
                 existing_rows: Dict[tuple[str, str], tuple] = {}
-                by_account: Dict[str, List[str]] = {}
-                for txn in transactions:
-                    by_account.setdefault(txn["accountId"], []).append(
-                        txn["transactionId"]
+                txn_ids = list(
+                    dict.fromkeys(txn["transactionId"] for txn in transactions)
+                )
+                for start in range(0, len(txn_ids), _SELECT_CHUNK_SIZE):
+                    chunk = txn_ids[start : start + _SELECT_CHUNK_SIZE]
+                    placeholders = ",".join("?" * len(chunk))
+                    cursor.execute(
+                        f"""SELECT
+                            accountId,
+                            transactionId,
+                            internalTransactionId,
+                            institutionId,
+                            iban,
+                            transactionDate,
+                            description,
+                            transactionValue,
+                            transactionCurrency,
+                            transactionStatus,
+                            rawTransaction
+                        FROM transactions
+                        WHERE accountId = ? AND transactionId IN ({placeholders})""",
+                        (account_id, *chunk),
                     )
-                for acct, txn_ids in by_account.items():
-                    for start in range(0, len(txn_ids), _SELECT_CHUNK_SIZE):
-                        chunk = txn_ids[start : start + _SELECT_CHUNK_SIZE]
-                        placeholders = ",".join("?" * len(chunk))
-                        cursor.execute(
-                            f"""SELECT
-                                accountId,
-                                transactionId,
-                                internalTransactionId,
-                                institutionId,
-                                iban,
-                                transactionDate,
-                                description,
-                                transactionValue,
-                                transactionCurrency,
-                                transactionStatus,
-                                rawTransaction
-                            FROM transactions
-                            WHERE accountId = ? AND transactionId IN ({placeholders})""",
-                            (acct, *chunk),
-                        )
-                        for row in cursor.fetchall():
-                            existing_rows[(row[0], row[1])] = tuple(row[2:])
+                    for row in cursor.fetchall():
+                        existing_rows[(row[0], row[1])] = tuple(row[2:])
 
                 new_transactions = []
                 updated_count = 0

--- a/leggen/repositories/transaction_repository.py
+++ b/leggen/repositories/transaction_repository.py
@@ -1,5 +1,4 @@
 import json
-import sqlite3
 from typing import Any, Dict, List, Optional, Union
 
 from loguru import logger
@@ -109,77 +108,75 @@ class TransactionRepository:
             with get_db_connection() as conn:
                 cursor = conn.cursor()
 
-                select_sql = """SELECT
-                    internalTransactionId,
-                    institutionId,
-                    iban,
-                    transactionDate,
-                    description,
-                    transactionValue,
-                    transactionCurrency,
-                    transactionStatus,
-                    rawTransaction
-                FROM transactions WHERE accountId = ? AND transactionId = ?"""
-
-                insert_sql = """INSERT OR REPLACE INTO transactions (
-                    accountId,
-                    transactionId,
-                    internalTransactionId,
-                    institutionId,
-                    iban,
-                    transactionDate,
-                    description,
-                    transactionValue,
-                    transactionCurrency,
-                    transactionStatus,
-                    rawTransaction
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
+                # One SELECT per account in the batch instead of one per
+                # transaction: load the existing rows into memory and compare
+                # there. A full-history sync is thousands of rows, not millions.
+                existing_rows: Dict[tuple[str, str], tuple] = {}
+                for acct in {txn["accountId"] for txn in transactions}:
+                    cursor.execute(
+                        """SELECT
+                            accountId,
+                            transactionId,
+                            internalTransactionId,
+                            institutionId,
+                            iban,
+                            transactionDate,
+                            description,
+                            transactionValue,
+                            transactionCurrency,
+                            transactionStatus,
+                            rawTransaction
+                        FROM transactions WHERE accountId = ?""",
+                        (acct,),
+                    )
+                    for row in cursor.fetchall():
+                        existing_rows[(row[0], row[1])] = tuple(row[2:])
 
                 new_transactions = []
                 updated_count = 0
+                rows_to_write = []
 
                 for transaction in transactions:
-                    try:
-                        row_values = (
-                            transaction.get("internalTransactionId"),
-                            transaction["institutionId"],
-                            transaction["iban"],
-                            transaction["transactionDate"],
-                            transaction["description"],
-                            transaction["transactionValue"],
-                            transaction["transactionCurrency"],
-                            transaction["transactionStatus"],
-                            json.dumps(transaction["rawTransaction"]),
-                        )
+                    row_values = (
+                        transaction.get("internalTransactionId"),
+                        transaction["institutionId"],
+                        transaction["iban"],
+                        transaction["transactionDate"],
+                        transaction["description"],
+                        transaction["transactionValue"],
+                        transaction["transactionCurrency"],
+                        transaction["transactionStatus"],
+                        json.dumps(transaction["rawTransaction"]),
+                    )
+                    key = (transaction["accountId"], transaction["transactionId"])
+                    existing = existing_rows.get(key)
 
-                        cursor.execute(
-                            select_sql,
-                            (transaction["accountId"], transaction["transactionId"]),
-                        )
-                        existing = cursor.fetchone()
-
-                        if existing is not None and tuple(existing) == row_values:
-                            continue
-
-                        cursor.execute(
-                            insert_sql,
-                            (
-                                transaction["accountId"],
-                                transaction["transactionId"],
-                                *row_values,
-                            ),
-                        )
-
-                        if existing is None:
-                            new_transactions.append(transaction)
-                        else:
-                            updated_count += 1
-
-                    except sqlite3.IntegrityError as e:
-                        logger.warning(
-                            f"Failed to insert transaction {transaction.get('transactionId')}: {e}"
-                        )
+                    if existing is not None and existing == row_values:
                         continue
+
+                    rows_to_write.append((*key, *row_values))
+                    if existing is None:
+                        new_transactions.append(transaction)
+                    else:
+                        updated_count += 1
+
+                if rows_to_write:
+                    cursor.executemany(
+                        """INSERT OR REPLACE INTO transactions (
+                            accountId,
+                            transactionId,
+                            internalTransactionId,
+                            institutionId,
+                            iban,
+                            transactionDate,
+                            description,
+                            transactionValue,
+                            transactionCurrency,
+                            transactionStatus,
+                            rawTransaction
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                        rows_to_write,
+                    )
 
                 conn.commit()
 

--- a/leggen/utils/config.py
+++ b/leggen/utils/config.py
@@ -112,6 +112,11 @@ class Config:
         self.save_config()
 
     @property
+    def is_loaded(self) -> bool:
+        """Whether a configuration has been loaded, without triggering a load."""
+        return self._config is not None
+
+    @property
     def config(self) -> Dict[str, Any]:
         if self._config is None:
             self.load_config()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -158,6 +158,46 @@ def api_client(fastapi_app):
 
 
 @pytest.fixture
+def raw_api_client(fastapi_app):
+    """Authenticated test client that returns 500 responses instead of
+    re-raising unhandled route exceptions — for testing the global handlers."""
+    client = TestClient(fastapi_app, raise_server_exceptions=False)
+    client.headers["X-API-Key"] = "lgn_test-api-key-for-testing"
+    return client
+
+
+def persist_transactions(rows: list[tuple]) -> None:
+    """Insert transactions into the temp DB via the real repository.
+
+    Each row: (txn_id, account_id, date, value, currency, status).
+    """
+    from leggen.repositories import TransactionRepository
+
+    repo = TransactionRepository()
+    transactions = [
+        {
+            "transactionId": txn_id,
+            "internalTransactionId": f"int-{txn_id}",
+            "institutionId": "TEST_BANK",
+            "iban": "LT313250081177977789",
+            "accountId": account_id,
+            "transactionDate": date,
+            "description": f"Transaction {txn_id}",
+            "transactionValue": value,
+            "transactionCurrency": currency,
+            "transactionStatus": status,
+            "rawTransaction": {"transactionId": txn_id},
+        }
+        for txn_id, account_id, date, value, currency, status in rows
+    ]
+    by_account: dict[str, list] = {}
+    for txn in transactions:
+        by_account.setdefault(txn["accountId"], []).append(txn)
+    for account_id, txns in by_account.items():
+        repo.persist(account_id, txns)
+
+
+@pytest.fixture
 def mock_account_repo():
     """Create mock AccountRepository for testing."""
     from unittest.mock import MagicMock

--- a/tests/unit/test_analytics_fix.py
+++ b/tests/unit/test_analytics_fix.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 
 import pytest
 
-from leggen.repositories import TransactionRepository
+from tests.conftest import persist_transactions
 
 
 @pytest.mark.api
@@ -13,33 +13,20 @@ class TestAnalyticsFix:
     """Stats aggregation covers every matching transaction."""
 
     def test_transaction_stats_uses_all_transactions(self, api_client, mock_db_path):
-        """600 transactions — well past any page size — are all aggregated."""
+        """600 transactions - well past any page size - are all aggregated."""
         base_date = datetime(2024, 6, 1)
-        transactions = [
-            {
-                "transactionId": f"txn-{i}",
-                "internalTransactionId": f"int-{i}",
-                "institutionId": "TEST_BANK",
-                "iban": "LT313250081177977789",
-                "accountId": f"account-{i % 3}",
-                "transactionDate": (
-                    base_date + timedelta(minutes=i % (300 * 24 * 60))
-                ).isoformat(),
-                "description": f"Transaction {i}",
-                "transactionValue": 10.0 if i % 2 == 0 else -5.0,
-                "transactionCurrency": "EUR",
-                "transactionStatus": "booked",
-                "rawTransaction": {"transactionId": f"txn-{i}"},
-            }
+        rows = [
+            (
+                f"txn-{i}",
+                f"account-{i % 3}",
+                (base_date + timedelta(minutes=i)).isoformat(),
+                10.0 if i % 2 == 0 else -5.0,
+                "EUR",
+                "booked",
+            )
             for i in range(600)
         ]
-
-        repo = TransactionRepository()
-        for account in ("account-0", "account-1", "account-2"):
-            repo.persist(
-                account,
-                [txn for txn in transactions if txn["accountId"] == account],
-            )
+        persist_transactions(rows)
 
         response = api_client.get(
             "/api/v1/transactions/stats?date_from=2024-01-01&date_to=2025-06-01"

--- a/tests/unit/test_analytics_fix.py
+++ b/tests/unit/test_analytics_fix.py
@@ -1,85 +1,54 @@
-"""Tests for analytics fixes to ensure all transactions are used in statistics."""
+"""Regression test: statistics must cover the whole filtered history,
+not just the first page of transactions."""
 
 from datetime import datetime, timedelta
-from unittest.mock import Mock
 
 import pytest
-from fastapi.testclient import TestClient
 
-from leggen.commands.server import create_app
 from leggen.repositories import TransactionRepository
 
 
+@pytest.mark.api
 class TestAnalyticsFix:
-    """Test analytics fixes for transaction limits"""
+    """Stats aggregation covers every matching transaction."""
 
-    @pytest.fixture
-    def client(self):
-        app = create_app()
-        return TestClient(app)
+    def test_transaction_stats_uses_all_transactions(self, api_client, mock_db_path):
+        """600 transactions — well past any page size — are all aggregated."""
+        base_date = datetime(2024, 6, 1)
+        transactions = [
+            {
+                "transactionId": f"txn-{i}",
+                "internalTransactionId": f"int-{i}",
+                "institutionId": "TEST_BANK",
+                "iban": "LT313250081177977789",
+                "accountId": f"account-{i % 3}",
+                "transactionDate": (
+                    base_date + timedelta(minutes=i % (300 * 24 * 60))
+                ).isoformat(),
+                "description": f"Transaction {i}",
+                "transactionValue": 10.0 if i % 2 == 0 else -5.0,
+                "transactionCurrency": "EUR",
+                "transactionStatus": "booked",
+                "rawTransaction": {"transactionId": f"txn-{i}"},
+            }
+            for i in range(600)
+        ]
 
-    @pytest.fixture
-    def mock_transaction_repo(self):
-        return Mock()
-
-    @pytest.mark.asyncio
-    async def test_transaction_stats_uses_all_transactions(self, mock_transaction_repo):
-        """Test that transaction stats endpoint uses all transactions (not limited to 100)"""
-        # Mock data for 600 transactions (simulating the issue)
-        mock_transactions = []
-        for i in range(600):
-            mock_transactions.append(
-                {
-                    "transactionId": f"txn-{i}",
-                    "transactionDate": (
-                        datetime.now() - timedelta(days=i % 365)
-                    ).isoformat(),
-                    "description": f"Transaction {i}",
-                    "transactionValue": 10.0 if i % 2 == 0 else -5.0,
-                    "transactionCurrency": "EUR",
-                    "transactionStatus": "booked",
-                    "accountId": f"account-{i % 3}",
-                }
+        repo = TransactionRepository()
+        for account in ("account-0", "account-1", "account-2"):
+            repo.persist(
+                account,
+                [txn for txn in transactions if txn["accountId"] == account],
             )
 
-        mock_transaction_repo.get_transactions.return_value = mock_transactions
-
-        app = create_app()
-        app.dependency_overrides[TransactionRepository] = lambda: mock_transaction_repo
-        client = TestClient(app)
-        client.headers["X-API-Key"] = "lgn_test-api-key-for-testing"
-
-        response = client.get(
-            "/api/v1/transactions/stats?date_from=2024-01-01&date_to=2025-01-01"
+        response = api_client.get(
+            "/api/v1/transactions/stats?date_from=2024-01-01&date_to=2025-06-01"
         )
 
         assert response.status_code == 200
-        data = response.json()
+        stats = response.json()
 
-        # Verify that limit=None was passed to get all transactions
-        mock_transaction_repo.get_transactions.assert_called_once()
-        call_args = mock_transaction_repo.get_transactions.call_args
-        assert call_args.kwargs.get("limit") is None, (
-            "Stats endpoint should pass limit=None to get all transactions"
-        )
-
-        # Verify that the response contains stats for all 600 transactions
-        stats = data
-        assert stats["total_transactions"] == 600, (
-            "Should process all 600 transactions, not just 100"
-        )
-
-        # Verify calculations are correct for all transactions
-        expected_income = sum(
-            txn["transactionValue"]
-            for txn in mock_transactions
-            if txn["transactionValue"] > 0
-        )
-        expected_expenses = sum(
-            abs(txn["transactionValue"])
-            for txn in mock_transactions
-            if txn["transactionValue"] < 0
-        )
-
-        assert stats["total_income"] == expected_income
-        assert stats["total_expenses"] == expected_expenses
+        assert stats["total_transactions"] == 600
+        assert stats["total_income"] == 10.0 * 300
+        assert stats["total_expenses"] == 5.0 * 300
+        assert stats["accounts_included"] == 3

--- a/tests/unit/test_api_accounts.py
+++ b/tests/unit/test_api_accounts.py
@@ -50,7 +50,9 @@ class TestAccountsAPI:
         ]
 
         mock_account_repo.get_accounts.return_value = mock_accounts
-        mock_balance_repo.get_balances.return_value = mock_balances
+        mock_balance_repo.get_latest_balances_by_account.return_value = {
+            "test-account-123": mock_balances
+        }
 
         fastapi_app.dependency_overrides[AccountRepository] = lambda: mock_account_repo
         fastapi_app.dependency_overrides[BalanceRepository] = lambda: mock_balance_repo
@@ -209,7 +211,7 @@ class TestAccountsAPI:
         ]
 
         mock_account_repo.get_accounts.return_value = mock_accounts
-        mock_balance_repo.get_balances.return_value = []
+        mock_balance_repo.get_latest_balances_by_account.return_value = {}
 
         fastapi_app.dependency_overrides[AccountRepository] = lambda: mock_account_repo
         fastapi_app.dependency_overrides[BalanceRepository] = lambda: mock_balance_repo

--- a/tests/unit/test_api_errors.py
+++ b/tests/unit/test_api_errors.py
@@ -24,13 +24,14 @@ class TestErrorEnvelope:
         assert response.status_code == 404
         _assert_envelope(response.json(), 404, "NOT_FOUND")
 
-    def test_unhandled_route_error_uses_sanitized_500(self, fastapi_app, mock_db_path):
+    def test_unhandled_route_error_uses_sanitized_500(
+        self, fastapi_app, mock_db_path, raw_api_client
+    ):
         """Routes have no blanket handlers; the global handler renders the
         sanitized 500 with a full traceback in the log."""
         from leggen.background.scheduler import scheduler
 
-        client = TestClient(fastapi_app, raise_server_exceptions=False)
-        client.headers["X-API-Key"] = "lgn_test-api-key-for-testing"
+        client = raw_api_client
 
         mock_service = MagicMock()
         mock_service.sync_all_accounts.side_effect = Exception("db is locked")
@@ -47,13 +48,10 @@ class TestErrorEnvelope:
         assert "db is locked" not in response.text
 
     def test_unhandled_exception_returns_json_not_plain_text(
-        self, fastapi_app, mock_db_path
+        self, fastapi_app, mock_db_path, raw_api_client
     ):
         """Routes without a try/except used to fall through to a plain-text 500."""
-        # raise_server_exceptions=False so TestClient returns the handler's
-        # response instead of re-raising the original exception.
-        client = TestClient(fastapi_app, raise_server_exceptions=False)
-        client.headers["X-API-Key"] = "lgn_test-api-key-for-testing"
+        client = raw_api_client
 
         with patch.object(
             SessionRepository,

--- a/tests/unit/test_api_errors.py
+++ b/tests/unit/test_api_errors.py
@@ -24,24 +24,27 @@ class TestErrorEnvelope:
         assert response.status_code == 404
         _assert_envelope(response.json(), 404, "NOT_FOUND")
 
-    def test_sanitized_500_keeps_route_message(
-        self, fastapi_app, api_client, mock_db_path
-    ):
-        """A route's own 500 message survives; the code is filled in for it."""
+    def test_unhandled_route_error_uses_sanitized_500(self, fastapi_app, mock_db_path):
+        """Routes have no blanket handlers; the global handler renders the
+        sanitized 500 with a full traceback in the log."""
         from leggen.background.scheduler import scheduler
+
+        client = TestClient(fastapi_app, raise_server_exceptions=False)
+        client.headers["X-API-Key"] = "lgn_test-api-key-for-testing"
 
         mock_service = MagicMock()
         mock_service.sync_all_accounts.side_effect = Exception("db is locked")
         scheduler.sync_service = mock_service
         try:
-            response = api_client.post("/api/v1/sync")
+            response = client.post("/api/v1/sync")
         finally:
             scheduler._sync_service = None
 
         assert response.status_code == 500
         body = response.json()
         _assert_envelope(body, 500, "INTERNAL_ERROR")
-        assert body["detail"] == "Failed to run sync."
+        assert body["detail"] == "Internal server error."
+        assert "db is locked" not in response.text
 
     def test_unhandled_exception_returns_json_not_plain_text(
         self, fastapi_app, mock_db_path

--- a/tests/unit/test_api_sync.py
+++ b/tests/unit/test_api_sync.py
@@ -117,20 +117,18 @@ class TestSyncAPI:
         response = api_client.post("/api/v1/sync")
 
         assert response.status_code == 409
-        assert response.json()["detail"] == "Sync is already running."
+        body = response.json()
+        assert body["detail"] == "Sync is already running"
+        assert body["code"] == "SYNC_ALREADY_RUNNING"
 
     def test_sync_failure_returns_sanitized_500(
-        self, fastapi_app, mock_db_path, mock_sync_service
+        self, fastapi_app, mock_db_path, mock_sync_service, raw_api_client
     ):
-        from fastapi.testclient import TestClient
-
         mock_sync_service.sync_all_accounts.side_effect = Exception(
             "sqlite3.OperationalError: /secret/path/leggen.db is locked"
         )
 
-        client = TestClient(fastapi_app, raise_server_exceptions=False)
-        client.headers["X-API-Key"] = "lgn_test-api-key-for-testing"
-        response = client.post("/api/v1/sync")
+        response = raw_api_client.post("/api/v1/sync")
 
         assert response.status_code == 500
         assert response.json()["detail"] == "Internal server error."

--- a/tests/unit/test_api_sync.py
+++ b/tests/unit/test_api_sync.py
@@ -120,16 +120,21 @@ class TestSyncAPI:
         assert response.json()["detail"] == "Sync is already running."
 
     def test_sync_failure_returns_sanitized_500(
-        self, fastapi_app, api_client, mock_db_path, mock_sync_service
+        self, fastapi_app, mock_db_path, mock_sync_service
     ):
+        from fastapi.testclient import TestClient
+
         mock_sync_service.sync_all_accounts.side_effect = Exception(
             "sqlite3.OperationalError: /secret/path/leggen.db is locked"
         )
 
-        response = api_client.post("/api/v1/sync")
+        client = TestClient(fastapi_app, raise_server_exceptions=False)
+        client.headers["X-API-Key"] = "lgn_test-api-key-for-testing"
+        response = client.post("/api/v1/sync")
 
         assert response.status_code == 500
-        assert response.json()["detail"] == "Failed to run sync."
+        assert response.json()["detail"] == "Internal server error."
+        assert "/secret/path" not in response.text
 
 
 def _reset_config_singleton() -> None:

--- a/tests/unit/test_api_transactions.py
+++ b/tests/unit/test_api_transactions.py
@@ -210,11 +210,11 @@ class TestTransactionsAPI:
     def test_get_transactions_database_error(
         self,
         fastapi_app,
-        api_client,
-        mock_config,
         mock_transaction_repo,
     ):
-        """Test handling database error when getting transactions."""
+        """A repository error surfaces as the sanitized global 500."""
+        from fastapi.testclient import TestClient
+
         mock_transaction_repo.get_transactions.side_effect = Exception(
             "Database connection failed"
         )
@@ -222,58 +222,58 @@ class TestTransactionsAPI:
         fastapi_app.dependency_overrides[TransactionRepository] = lambda: (
             mock_transaction_repo
         )
+        client = TestClient(fastapi_app, raise_server_exceptions=False)
+        client.headers["X-API-Key"] = "lgn_test-api-key-for-testing"
 
-        with patch("leggen.utils.config.config", mock_config):
-            response = api_client.get("/api/v1/transactions")
+        response = client.get("/api/v1/transactions")
 
         fastapi_app.dependency_overrides.clear()
 
         assert response.status_code == 500
-        assert "Failed to get transactions" in response.json()["detail"]
+        assert response.json()["detail"] == "Internal server error."
 
-    def test_get_transaction_stats_success(
-        self,
-        fastapi_app,
-        api_client,
-        mock_config,
-        mock_transaction_repo,
-    ):
-        """Test successful retrieval of transaction statistics from database."""
-        mock_transactions = [
+    @staticmethod
+    def _persist_txns(rows):
+        """Insert transactions into the temp DB via the real repository.
+
+        Each row: (txn_id, account_id, date, value, currency, status).
+        """
+        repo = TransactionRepository()
+        transactions = [
             {
-                "internalTransactionId": "txn-001",
-                "transactionDate": datetime(2025, 9, 1, 9, 30),
-                "transactionValue": -10.50,
-                "transactionStatus": "booked",
-                "accountId": "test-account-123",
-            },
-            {
-                "internalTransactionId": "txn-002",
-                "transactionDate": datetime(2025, 9, 2, 14, 15),
-                "transactionValue": 100.00,
-                "transactionStatus": "pending",
-                "accountId": "test-account-123",
-            },
-            {
-                "internalTransactionId": "txn-003",
-                "transactionDate": datetime(2025, 9, 3, 16, 45),
-                "transactionValue": -25.30,
-                "transactionStatus": "booked",
-                "accountId": "other-account-456",
-            },
+                "transactionId": txn_id,
+                "internalTransactionId": f"int-{txn_id}",
+                "institutionId": "TEST_BANK",
+                "iban": "LT313250081177977789",
+                "accountId": account_id,
+                "transactionDate": date,
+                "description": f"Transaction {txn_id}",
+                "transactionValue": value,
+                "transactionCurrency": currency,
+                "transactionStatus": status,
+                "rawTransaction": {"transactionId": txn_id},
+            }
+            for txn_id, account_id, date, value, currency, status in rows
         ]
+        by_account: dict[str, list] = {}
+        for txn in transactions:
+            by_account.setdefault(txn["accountId"], []).append(txn)
+        for account_id, txns in by_account.items():
+            repo.persist(account_id, txns)
 
-        mock_transaction_repo.get_transactions.return_value = mock_transactions
-        fastapi_app.dependency_overrides[TransactionRepository] = lambda: (
-            mock_transaction_repo
+    def test_get_transaction_stats_success(self, api_client, mock_db_path):
+        """Stats are aggregated in SQL over the real database."""
+        self._persist_txns(
+            [
+                ("t1", "acc-1", "2025-09-01T09:30:00", -10.50, "EUR", "booked"),
+                ("t2", "acc-1", "2025-09-02T14:15:00", 100.00, "EUR", "pending"),
+                ("t3", "acc-2", "2025-09-03T16:45:00", -25.30, "EUR", "booked"),
+            ]
         )
 
-        with patch("leggen.utils.config.config", mock_config):
-            response = api_client.get(
-                "/api/v1/transactions/stats?date_from=2025-08-01&date_to=2025-10-01"
-            )
-
-        fastapi_app.dependency_overrides.clear()
+        response = api_client.get(
+            "/api/v1/transactions/stats?date_from=2025-08-01&date_to=2025-10-01"
+        )
 
         assert response.status_code == 200
         data = response.json()
@@ -283,73 +283,118 @@ class TestTransactionsAPI:
         assert data["total_transactions"] == 3
         assert data["booked_transactions"] == 2
         assert data["pending_transactions"] == 1
+        assert data["currency"] == "EUR"
         assert data["total_income"] == 100.00
         assert data["total_expenses"] == 35.80  # abs(-10.50) + abs(-25.30)
         assert data["net_change"] == 64.20  # 100.00 - 35.80
         assert data["accounts_included"] == 2  # Two unique account IDs
+        assert data["average_transaction"] == round(64.20 / 3, 2)
 
-        # Average transaction: ((-10.50) + 100.00 + (-25.30)) / 3 = 64.20 / 3 = 21.4
-        expected_avg = round(64.20 / 3, 2)
-        assert data["average_transaction"] == expected_avg
-
-    def test_get_transaction_stats_with_account_filter(
-        self,
-        fastapi_app,
-        api_client,
-        mock_config,
-        mock_transaction_repo,
-    ):
-        """Test getting transaction stats filtered by account."""
-        mock_transactions = [
-            {
-                "internalTransactionId": "txn-001",
-                "transactionDate": datetime(2025, 9, 1, 9, 30),
-                "transactionValue": -10.50,
-                "transactionStatus": "booked",
-                "accountId": "test-account-123",
-            }
-        ]
-
-        mock_transaction_repo.get_transactions.return_value = mock_transactions
-
-        fastapi_app.dependency_overrides[TransactionRepository] = lambda: (
-            mock_transaction_repo
+    def test_get_transaction_stats_with_account_filter(self, api_client, mock_db_path):
+        """Stats filtered by account only aggregate that account."""
+        self._persist_txns(
+            [
+                ("t1", "acc-1", "2025-09-01T09:30:00", -10.50, "EUR", "booked"),
+                ("t2", "acc-2", "2025-09-02T14:15:00", 100.00, "EUR", "booked"),
+            ]
         )
 
-        with patch("leggen.utils.config.config", mock_config):
-            response = api_client.get(
-                "/api/v1/transactions/stats?date_from=2025-08-01&date_to=2025-10-01&account_id=test-account-123"
-            )
-
-        fastapi_app.dependency_overrides.clear()
+        response = api_client.get(
+            "/api/v1/transactions/stats"
+            "?date_from=2025-08-01&date_to=2025-10-01&account_id=acc-1"
+        )
 
         assert response.status_code == 200
+        data = response.json()
+        assert data["total_transactions"] == 1
+        assert data["total_expenses"] == 10.50
+        assert data["total_income"] == 0
+        assert data["accounts_included"] == 1
 
-        # Verify the repository was called with account filter
-        mock_transaction_repo.get_transactions.assert_called_once()
-        call_kwargs = mock_transaction_repo.get_transactions.call_args.kwargs
-        assert call_kwargs["account_id"] == "test-account-123"
-
-    def test_get_transaction_stats_empty_result(
-        self,
-        fastapi_app,
-        api_client,
-        mock_config,
-        mock_transaction_repo,
-    ):
-        """Test getting stats when no transactions match criteria."""
-        mock_transaction_repo.get_transactions.return_value = []
-
-        fastapi_app.dependency_overrides[TransactionRepository] = lambda: (
-            mock_transaction_repo
+    def test_get_transaction_stats_respects_date_range(self, api_client, mock_db_path):
+        """Transactions outside the requested range are not aggregated,
+        and the inclusive end date covers the whole day."""
+        self._persist_txns(
+            [
+                ("t1", "acc-1", "2025-08-27T09:30:00", -10.00, "EUR", "booked"),
+                ("t2", "acc-1", "2025-09-01T14:15:00", -20.00, "EUR", "booked"),
+                ("t3", "acc-1", "2025-09-04T23:00:00", -40.00, "EUR", "booked"),
+                ("t4", "acc-1", "2025-09-05T00:30:00", -80.00, "EUR", "booked"),
+            ]
         )
 
-        with patch("leggen.utils.config.config", mock_config):
-            response = api_client.get(
-                "/api/v1/transactions/stats?date_from=2025-01-01&date_to=2025-12-31"
-            )
+        response = api_client.get(
+            "/api/v1/transactions/stats?date_from=2025-08-28&date_to=2025-09-04"
+        )
 
-        fastapi_app.dependency_overrides.clear()
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_transactions"] == 2
+        assert data["total_expenses"] == 60.00  # t2 + t3; t1/t4 out of range
+
+    def test_get_transaction_stats_excludes_flagged_categories(
+        self, api_client, mock_db_path
+    ):
+        """Transactions in categories flagged exclude_from_stats are left out."""
+        from leggen.repositories.category_repository import CategoryRepository
+
+        self._persist_txns(
+            [
+                ("t1", "acc-1", "2025-09-01T09:30:00", -10.00, "EUR", "booked"),
+                ("t2", "acc-1", "2025-09-02T14:15:00", -20.00, "EUR", "booked"),
+            ]
+        )
+        category_repo = CategoryRepository()
+        cat = category_repo.create_category(
+            name="Internal transfers", color="#000000", exclude_from_stats=True
+        )
+        category_repo.assign_category(
+            account_id="acc-1",
+            transaction_id="t2",
+            category_id=cat["id"],
+            description="Transaction t2",
+            creditor_name="",
+            debtor_name="",
+        )
+
+        response = api_client.get(
+            "/api/v1/transactions/stats?date_from=2025-08-01&date_to=2025-10-01"
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_transactions"] == 1
+        assert data["total_expenses"] == 10.00
+
+    def test_get_transaction_stats_uses_dominant_currency(
+        self, api_client, mock_db_path
+    ):
+        """Money totals cover only the dominant currency; counts cover all."""
+        self._persist_txns(
+            [
+                ("t1", "acc-1", "2025-09-01T09:30:00", -10.00, "EUR", "booked"),
+                ("t2", "acc-1", "2025-09-02T14:15:00", 50.00, "EUR", "booked"),
+                ("t3", "acc-1", "2025-09-03T16:45:00", -999.00, "USD", "booked"),
+            ]
+        )
+
+        response = api_client.get(
+            "/api/v1/transactions/stats?date_from=2025-08-01&date_to=2025-10-01"
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_transactions"] == 3
+        assert data["currency"] == "EUR"
+        assert data["total_expenses"] == 10.00  # USD amount not mixed in
+        assert data["total_income"] == 50.00
+        assert data["average_transaction"] == 20.00  # (50 - 10) / 2 EUR txns
+
+    def test_get_transaction_stats_empty_result(self, api_client, mock_db_path):
+        """Stats over an empty database return zeroed totals."""
+        response = api_client.get(
+            "/api/v1/transactions/stats?date_from=2025-01-01&date_to=2025-12-31"
+        )
 
         assert response.status_code == 200
         data = response.json()
@@ -360,74 +405,34 @@ class TestTransactionsAPI:
         assert data["net_change"] == 0.0
         assert data["average_transaction"] == 0  # Division by zero handled
         assert data["accounts_included"] == 0
+        assert data["currency"] is None
 
     def test_get_transaction_stats_database_error(
         self,
         fastapi_app,
-        api_client,
-        mock_config,
         mock_transaction_repo,
     ):
-        """Test handling database error when getting stats."""
-        mock_transaction_repo.get_transactions.side_effect = Exception(
+        """A repository error surfaces as the sanitized global 500."""
+        from fastapi.testclient import TestClient
+
+        mock_transaction_repo.get_stats_totals.side_effect = Exception(
             "Database connection failed"
         )
 
         fastapi_app.dependency_overrides[TransactionRepository] = lambda: (
             mock_transaction_repo
         )
+        client = TestClient(fastapi_app, raise_server_exceptions=False)
+        client.headers["X-API-Key"] = "lgn_test-api-key-for-testing"
 
-        with patch("leggen.utils.config.config", mock_config):
-            response = api_client.get(
-                "/api/v1/transactions/stats?date_from=2025-01-01&date_to=2025-12-31"
-            )
+        response = client.get(
+            "/api/v1/transactions/stats?date_from=2025-01-01&date_to=2025-12-31"
+        )
 
         fastapi_app.dependency_overrides.clear()
 
         assert response.status_code == 500
-        assert "Failed to get transaction stats" in response.json()["detail"]
-
-    def test_get_transaction_stats_custom_date_range(
-        self,
-        fastapi_app,
-        api_client,
-        mock_config,
-        mock_transaction_repo,
-    ):
-        """Test getting transaction stats for a custom date range."""
-        mock_transactions = [
-            {
-                "internalTransactionId": "txn-001",
-                "transactionDate": datetime(2025, 9, 1, 9, 30),
-                "transactionValue": -10.50,
-                "transactionStatus": "booked",
-                "accountId": "test-account-123",
-            }
-        ]
-
-        mock_transaction_repo.get_transactions.return_value = mock_transactions
-
-        fastapi_app.dependency_overrides[TransactionRepository] = lambda: (
-            mock_transaction_repo
-        )
-
-        with patch("leggen.utils.config.config", mock_config):
-            response = api_client.get(
-                "/api/v1/transactions/stats?date_from=2025-08-28&date_to=2025-09-04"
-            )
-
-        fastapi_app.dependency_overrides.clear()
-
-        assert response.status_code == 200
-        data = response.json()
-        assert data["date_from"] == "2025-08-28"
-        assert data["date_to"] == "2025-09-04"
-
-        # Verify the repository was called with the date range
-        mock_transaction_repo.get_transactions.assert_called_once()
-        call_kwargs = mock_transaction_repo.get_transactions.call_args.kwargs
-        assert call_kwargs["date_from"] == "2025-08-28"
-        assert call_kwargs["date_to"] == "2025-09-04"
+        assert response.json()["detail"] == "Internal server error."
 
     def test_get_transactions_invalid_per_page(self, api_client, mock_config):
         """per_page below 1 is rejected instead of dividing by zero."""

--- a/tests/unit/test_api_transactions.py
+++ b/tests/unit/test_api_transactions.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from leggen.repositories import TransactionRepository
+from tests.conftest import persist_transactions
 
 
 @pytest.mark.api
@@ -210,11 +211,10 @@ class TestTransactionsAPI:
     def test_get_transactions_database_error(
         self,
         fastapi_app,
+        raw_api_client,
         mock_transaction_repo,
     ):
         """A repository error surfaces as the sanitized global 500."""
-        from fastapi.testclient import TestClient
-
         mock_transaction_repo.get_transactions.side_effect = Exception(
             "Database connection failed"
         )
@@ -222,10 +222,8 @@ class TestTransactionsAPI:
         fastapi_app.dependency_overrides[TransactionRepository] = lambda: (
             mock_transaction_repo
         )
-        client = TestClient(fastapi_app, raise_server_exceptions=False)
-        client.headers["X-API-Key"] = "lgn_test-api-key-for-testing"
 
-        response = client.get("/api/v1/transactions")
+        response = raw_api_client.get("/api/v1/transactions")
 
         fastapi_app.dependency_overrides.clear()
 
@@ -233,33 +231,8 @@ class TestTransactionsAPI:
         assert response.json()["detail"] == "Internal server error."
 
     @staticmethod
-    def _persist_txns(rows):
-        """Insert transactions into the temp DB via the real repository.
-
-        Each row: (txn_id, account_id, date, value, currency, status).
-        """
-        repo = TransactionRepository()
-        transactions = [
-            {
-                "transactionId": txn_id,
-                "internalTransactionId": f"int-{txn_id}",
-                "institutionId": "TEST_BANK",
-                "iban": "LT313250081177977789",
-                "accountId": account_id,
-                "transactionDate": date,
-                "description": f"Transaction {txn_id}",
-                "transactionValue": value,
-                "transactionCurrency": currency,
-                "transactionStatus": status,
-                "rawTransaction": {"transactionId": txn_id},
-            }
-            for txn_id, account_id, date, value, currency, status in rows
-        ]
-        by_account: dict[str, list] = {}
-        for txn in transactions:
-            by_account.setdefault(txn["accountId"], []).append(txn)
-        for account_id, txns in by_account.items():
-            repo.persist(account_id, txns)
+    def _persist_txns(rows: list[tuple]) -> None:
+        persist_transactions(rows)
 
     def test_get_transaction_stats_success(self, api_client, mock_db_path):
         """Stats are aggregated in SQL over the real database."""
@@ -410,11 +383,10 @@ class TestTransactionsAPI:
     def test_get_transaction_stats_database_error(
         self,
         fastapi_app,
+        raw_api_client,
         mock_transaction_repo,
     ):
         """A repository error surfaces as the sanitized global 500."""
-        from fastapi.testclient import TestClient
-
         mock_transaction_repo.get_stats_totals.side_effect = Exception(
             "Database connection failed"
         )
@@ -422,10 +394,8 @@ class TestTransactionsAPI:
         fastapi_app.dependency_overrides[TransactionRepository] = lambda: (
             mock_transaction_repo
         )
-        client = TestClient(fastapi_app, raise_server_exceptions=False)
-        client.headers["X-API-Key"] = "lgn_test-api-key-for-testing"
 
-        response = client.get(
+        response = raw_api_client.get(
             "/api/v1/transactions/stats?date_from=2025-01-01&date_to=2025-12-31"
         )
 

--- a/tests/unit/test_transaction_repository.py
+++ b/tests/unit/test_transaction_repository.py
@@ -58,3 +58,28 @@ class TestTransactionRepositoryPersist:
         stored = repo.get_transaction_by_id("IBAN1", "tx-1")
         assert stored is not None
         assert stored["transactionStatus"] == "BOOK"
+
+    def test_mismatched_account_id_rejected(self, mock_db_path):
+        """Rows for another account must fail fast, not write under the
+        wrong primary key while reporting success for account_id."""
+        repo = TransactionRepository()
+
+        with pytest.raises(ValueError, match="IBAN2"):
+            repo.persist("IBAN1", [_make_transaction(accountId="IBAN2")])
+
+    def test_duplicate_id_in_batch_counted_once(self, mock_db_path):
+        """The same transactionId twice in one batch (e.g. a pending and a
+        booked entry in one fetch) is one insert plus one update, never two
+        inserts — double-counting meant duplicate notifications."""
+        repo = TransactionRepository()
+
+        new_transactions, updated_count = repo.persist(
+            "IBAN1",
+            [
+                _make_transaction(transactionStatus="PNDG"),
+                _make_transaction(transactionStatus="BOOK"),
+            ],
+        )
+
+        assert len(new_transactions) == 1
+        assert updated_count == 1


### PR DESCRIPTION
Backend cleanup from the polish review, in five commits. **Stacked on #64** — will rebase onto main once that merges.

**Trust the global exception handlers** (~25 blanket `try/except → HTTPException(500)` wrappers deleted)
The global handler already renders a sanitized 500 envelope with a full traceback in the log; routes keep only targeted translations (404/400/409, `MaskedSecretError`). `POST /sync` also stops re-mapping `SyncAlreadyRunningError` — it's a `ConflictError` the global handler renders as 409 with code `SYNC_ALREADY_RUNNING`.

**Aggregate transaction stats in SQL**
`GET /transactions/stats` used to load the entire filtered history into Python (with a `json.loads` per row). One SQL aggregate now handles totals, the `exclude_from_stats` join, and dominant-currency selection. Stats tests now run against a real temp database, covering the exclusion join, currency dominance (incl. NULL-currency legacy rows), and date-range edges.

**Fix N+1 queries and batch persistence**
`GET /accounts`/`GET /balances` fetch latest balances in one query (grouping lives in `BalanceRepository`). `TransactionRepository.persist` replaces SELECT+INSERT per transaction with one chunked batch SELECT + `executemany`, handling in-batch duplicate IDs and falling back to per-row inserts if a bad row would abort the batch.

**Typed responses everywhere** (prerequisite for OpenAPI type generation — PR 5)
New response models: `TransactionStats`, `MonthlyStats`, `CategoryStats`, `Balance`, `Country`, `HealthStatus`, `NotificationServiceStatus`, `BackupInfo`, plus `PaginatedResponse[SyncOperation]`. The frontend `Balance` mirror gains the nullability the runtime always had.

**Review pass applied**
The branch was adversarially reviewed (8 angles); confirmed findings are folded into the last commit — including two real bugs the review caught in this branch's own new code (batch dedup double-counting duplicates within one fetch, and whole-history preloading on incremental syncs).

Deferred as follow-ups (pre-existing, noted by the review): `group_by=month` ignores min/max/search/category filters (predates this PR); dominant-currency selection differs between totals and monthly/category aggregates (also pre-existing); monthly/category aggregation still lives in `data_processors` with its own connection handling.

Verified: 221 tests pass, mypy clean, frontend builds, plus a live smoke test of every touched endpoint against `generate_sample_db` data.

PR 3 of the polish series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)